### PR TITLE
Refactor UIColor

### DIFF
--- a/Eatery Blue.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Eatery Blue.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire",
+        "state": {
+          "branch": null,
+          "revision": "8dd85aee02e39dd280c75eef88ffdb86eed4b07b",
+          "version": "5.6.2"
+        }
+      },
+      {
         "package": "Fuse",
         "repositoryURL": "https://github.com/krisk/fuse-swift",
         "state": {
@@ -44,6 +53,15 @@
           "branch": null,
           "revision": "e1465042f195f374b94f915ba8ca49de24300a0d",
           "version": "1.0.2"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log",
+        "state": {
+          "branch": null,
+          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
+          "version": "1.4.4"
         }
       },
       {

--- a/Eatery Blue/Eatery Blue.xcodeproj/project.pbxproj
+++ b/Eatery Blue/Eatery Blue.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		5DF938D1277662CC008ED0A1 /* PaymentMethodFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF938D0277662CC008ED0A1 /* PaymentMethodFilterView.swift */; };
 		5DF938D327768B84008ED0A1 /* SheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF938D227768B84008ED0A1 /* SheetViewController.swift */; };
 		5DF938D527768DDC008ED0A1 /* PaymentMethodsSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF938D427768DDC008ED0A1 /* PaymentMethodsSheetViewController.swift */; };
+		BFD955952900A8150049D77C /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD955942900A8150049D77C /* UIColor.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -290,6 +291,7 @@
 		5DF938D0277662CC008ED0A1 /* PaymentMethodFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodFilterView.swift; sourceTree = "<group>"; };
 		5DF938D227768B84008ED0A1 /* SheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetViewController.swift; sourceTree = "<group>"; };
 		5DF938D427768DDC008ED0A1 /* PaymentMethodsSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsSheetViewController.swift; sourceTree = "<group>"; };
+		BFD955942900A8150049D77C /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -570,6 +572,7 @@
 				5DF30490277696EF00E2C9A4 /* NSTextAttachment.swift */,
 				5DF5F7D5277404C8001ADCDC /* UIFont.swift */,
 				5DA434BD278B6EC7001337FD /* UITableViewCell.swift */,
+				BFD955942900A8150049D77C /* UIColor.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -940,6 +943,7 @@
 				5DBA899C2783EE07002DCA6B /* OnboardingStartViewController.swift in Sources */,
 				5DBA89962783CCAA002DCA6B /* LogoRefreshControl.swift in Sources */,
 				5D0CDC452774E7EA00AD0E27 /* EateryPillButtonStackView.swift in Sources */,
+				BFD955952900A8150049D77C /* UIColor.swift in Sources */,
 				5D3A149B27A219B600768E13 /* SettingsAboutAppDevHeaderView.swift in Sources */,
 				5D73C37B2780D0740020507C /* HomeSearchEmptyViewController.swift in Sources */,
 				5DF304AD2779209E00E2C9A4 /* MenuDayPickerCell.swift in Sources */,

--- a/Eatery Blue/Eatery Blue/Extensions/UIColor.swift
+++ b/Eatery Blue/Eatery Blue/Extensions/UIColor.swift
@@ -1,0 +1,32 @@
+//
+//  UIColor.swift
+//  Eatery Blue
+//
+//  Created by alden lamp on 10/19/22.
+//
+
+import UIKit
+
+extension UIColor {
+    
+    enum Eatery {
+        static let blue = UIColor(named: "EateryBlue")!
+        static let blueLight = UIColor(named: "EateryBlueLight")!
+        static let blueMedium = UIColor(named: "EateryBlueMedium")!
+        static let green = UIColor(named: "EateryGreen")!
+        static let orange = UIColor(named: "EateryOrange")!
+        static let red = UIColor(named: "EateryRed")!
+        static let redLight = UIColor(named: "EateryRedLight")!
+        static let gray00 = UIColor(named: "Gray00")!
+        static let gray01 = UIColor(named: "Gray01")!
+        static let gray02 = UIColor(named: "Gray02")!
+        static let gray03 = UIColor(named: "Gray03")!
+        static let gray04 = UIColor(named: "Gray04")!
+        static let gray05 = UIColor(named: "Gray05")!
+        static let gray06 = UIColor(named: "Gray06")!
+        static let black = UIColor(named: "Black")!
+        static let offWhite = UIColor(named: "OffWhite")!
+        static let shadowLight = UIColor(named: "ShadowLight")!
+    }
+    
+}

--- a/Eatery Blue/Eatery Blue/Model/EateryFormatter.swift
+++ b/Eatery Blue/Eatery Blue/Model/EateryFormatter.swift
@@ -38,27 +38,27 @@ class EateryFormatter {
             let timeString = timeFormatter.string(from: event.endDate)
             return NSAttributedString(
                 string: "Open until \(timeString)",
-                attributes: [.foregroundColor: UIColor(named: "EateryOrange") as Any]
+                attributes: [.foregroundColor: UIColor.Eatery.orange as Any]
             )
 
         case .closed:
             return NSAttributedString(
                 string: "Closed",
-                attributes: [.foregroundColor: UIColor(named: "EateryRed") as Any]
+                attributes: [.foregroundColor: UIColor.Eatery.red as Any]
             )
 
         case .openingSoon(let event):
             let timeString = timeFormatter.string(from: event.startDate)
             return NSAttributedString(
                 string: "Opening at \(timeString)",
-                attributes: [.foregroundColor: UIColor(named: "EateryOrange") as Any]
+                attributes: [.foregroundColor: UIColor.Eatery.orange as Any]
             )
 
         case .closingSoon(let event):
             let timeString = timeFormatter.string(from: event.endDate)
             return NSAttributedString(
                 string: "Closing at \(timeString)",
-                attributes: [.foregroundColor: UIColor(named: "EateryOrange") as Any]
+                attributes: [.foregroundColor: UIColor.Eatery.orange as Any]
             )
 
         }
@@ -85,12 +85,12 @@ class EateryFormatter {
             if eatery.paymentMethods.contains(.mealSwipes) {
                 return NSAttributedString(
                     string: "Meal swipes allowed",
-                    attributes: [.foregroundColor: UIColor(named: "EateryBlue") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.blue as Any]
                 )
             } else if eatery.paymentMethods == [.cash, .credit] {
                 return NSAttributedString(
                     string: "Cash or credit only",
-                    attributes: [.foregroundColor: UIColor(named: "EateryGreen") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.green as Any]
                 )
             } else if let menuSummary = eatery.menuSummary {
                 return NSAttributedString(string: menuSummary)
@@ -104,28 +104,28 @@ class EateryFormatter {
                 if let _ = EateryStatus.previousEvent(eatery.events, date: date, on: day) {
                     return NSAttributedString(
                         string: "Re-opens at \(timeFormatter.string(from: nextEventOfDay.startDate))",
-                        attributes: [.foregroundColor: UIColor(named: "EateryOrange") as Any]
+                        attributes: [.foregroundColor: UIColor.Eatery.orange as Any]
                     )
                 } else {
                     return NSAttributedString(
                         string: "Opens at \(timeFormatter.string(from: nextEventOfDay.startDate))",
-                        attributes: [.foregroundColor: UIColor(named: "EateryOrange") as Any]
+                        attributes: [.foregroundColor: UIColor.Eatery.orange as Any]
                     )
                 }
             } else if let nextEventOfNextDay = EateryStatus.nextEvent(eatery.events, date: date, on: day.advanced(by: 1)) {
                 return NSAttributedString(
                     string: "Closed until \(timeFormatter.string(from: nextEventOfNextDay.startDate))",
-                    attributes: [.foregroundColor: UIColor(named: "EateryRed") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.red as Any]
                 )
             } else if let nextEvent = EateryStatus.nextEvent(eatery.events, date: date) {
                 return NSAttributedString(
                     string: "Closed until \(mediumDayMonthFormatter.string(from: nextEvent.startDate))",
-                    attributes: [.foregroundColor: UIColor(named: "EateryRed") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.red as Any]
                 )
             } else {
                 return NSAttributedString(
                     string: "Closed today",
-                    attributes: [.foregroundColor: UIColor(named: "EateryRed") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.red as Any]
                 )
             }
         }

--- a/Eatery Blue/Eatery Blue/UI/Account/AccountBalanceTableViewCell.swift
+++ b/Eatery Blue/Eatery Blue/UI/Account/AccountBalanceTableViewCell.swift
@@ -38,12 +38,12 @@ class AccountBalanceTableViewCell: UITableViewCell {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .subheadline, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpSubtitleLabel() {
         subtitleLabel.font = .preferredFont(for: .subheadline, weight: .semibold)
-        subtitleLabel.textColor = UIColor(named: "Black")
+        subtitleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/Account/AccountModelController.swift
+++ b/Eatery Blue/Eatery Blue/UI/Account/AccountModelController.swift
@@ -170,11 +170,11 @@ class AccountModelController: AccountViewController {
             case .bearBasic, .bearChoice, .bearTraditional:
                 subtitle.append(NSAttributedString(
                     string: "\(remaining)",
-                    attributes: [.foregroundColor: UIColor(named: "Black") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.black as Any]
                 ))
                 subtitle.append(NSAttributedString(
                     string: " remaining this week",
-                    attributes: [.foregroundColor: UIColor(named: "Gray05") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.gray05 as Any]
                 ))
 
             case .unlimited:
@@ -183,11 +183,11 @@ class AccountModelController: AccountViewController {
             case .offCampusValue, .flex:
                 subtitle.append(NSAttributedString(
                     string: "\(remaining)",
-                    attributes: [.foregroundColor: UIColor(named: "Black") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.black as Any]
                 ))
                 subtitle.append(NSAttributedString(
                     string: " remaining this semester",
-                    attributes: [.foregroundColor: UIColor(named: "Gray05") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.gray05 as Any]
                 ))
 
             default:
@@ -232,7 +232,7 @@ class AccountModelController: AccountViewController {
                 amount.append(NSAttributedString(string: "1"))
                 amount.append(NSAttributedString(
                     string: " swipe",
-                    attributes: [.foregroundColor: UIColor(named: "Gray05") as Any]
+                    attributes: [.foregroundColor: UIColor.Eatery.gray05 as Any]
                 ))
             } else {
                 amount.append(NSAttributedString(

--- a/Eatery Blue/Eatery Blue/UI/Account/AccountPickerCell.swift
+++ b/Eatery Blue/Eatery Blue/UI/Account/AccountPickerCell.swift
@@ -36,11 +36,11 @@ class AccountPickerCell: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .body, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpImageView() {
-        imageView.tintColor = UIColor(named: "Black")
+        imageView.tintColor = UIColor.Eatery.black
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/Account/AccountTransactionTableViewCell.swift
+++ b/Eatery Blue/Eatery Blue/UI/Account/AccountTransactionTableViewCell.swift
@@ -37,17 +37,17 @@ class AccountTransactionTableViewCell: UITableViewCell {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .footnote, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "EateryBlack")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpSubtitleLabel() {
         subtitleLabel.font = .preferredFont(for: .caption1, weight: .medium)
-        subtitleLabel.textColor = UIColor(named: "Gray05")
+        subtitleLabel.textColor = UIColor.Eatery.gray05
     }
 
     private func setUpAmountLabel() {
         amountLabel.font = .preferredFont(for: .footnote, weight: .semibold)
-        amountLabel.textColor = UIColor(named: "EateryBlack")
+        amountLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/Account/AccountTransactionsHeaderView.swift
+++ b/Eatery Blue/Eatery Blue/UI/Account/AccountTransactionsHeaderView.swift
@@ -74,7 +74,7 @@ class AccountTransactionsHeaderView: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .title2, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpButtonImageView() {
@@ -95,7 +95,7 @@ class AccountTransactionsHeaderView: UIView {
 
     private func setUpHeaderLabel() {
         headerLabel.font = .preferredFont(for: .body, weight: .semibold)
-        headerLabel.textColor = UIColor(named: "Black")
+        headerLabel.textColor = UIColor.Eatery.black
 
         headerLabelContainer.layoutMargins = UIEdgeInsets(top: 6, left: 16, bottom: 6, right: 16)
     }

--- a/Eatery Blue/Eatery Blue/UI/Account/AccountViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/Account/AccountViewController.swift
@@ -45,7 +45,7 @@ class AccountViewController: UIViewController {
 
     private func setUpNavigation() {
         let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = UIColor(named: "EateryBlue")
+        appearance.backgroundColor = UIColor.Eatery.blue
         appearance.titleTextAttributes = [
             .foregroundColor: UIColor.white,
             .font: UIFont.eateryNavigationBarTitleFont
@@ -139,7 +139,7 @@ extension AccountViewController: UITableViewDataSource {
                 
             } else if indexPath.row == balanceItems.count + 1 {
                 let view = UIView()
-                view.backgroundColor = UIColor(named: "Gray00")
+                view.backgroundColor = UIColor.Eatery.gray00
                 view.snp.makeConstraints { make in
                     make.height.equalTo(16)
                 }

--- a/Eatery Blue/Eatery Blue/UI/AlertMessage/AlertMessageView.swift
+++ b/Eatery Blue/Eatery Blue/UI/AlertMessage/AlertMessageView.swift
@@ -31,7 +31,7 @@ class AlertMessageView: UIView {
         layoutMargins = UIEdgeInsets(top: 12, left: 8, bottom: 12, right: 8)
 
         layer.cornerRadius = 8
-        backgroundColor = UIColor(named: "EateryRedLight")
+        backgroundColor = UIColor.Eatery.redLight
 
         addSubview(stackView)
         setUpStackView()
@@ -70,17 +70,17 @@ class AlertMessageView: UIView {
     }
 
     func setStyleError() {
-        backgroundColor = UIColor(named: "EateryRedLight")
+        backgroundColor = UIColor.Eatery.redLight
         imageView.image = UIImage(named: "Error")?.withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = UIColor(named: "EateryRed")
-        messageLabel.textColor = UIColor(named: "EateryRed")
+        imageView.tintColor = UIColor.Eatery.red
+        messageLabel.textColor = UIColor.Eatery.red
     }
 
     func setStyleInfo() {
-        backgroundColor = UIColor(named: "EateryBlueLight")
+        backgroundColor = UIColor.Eatery.blueLight
         imageView.image = UIImage(named: "Info")?.withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = UIColor(named: "EateryBlue")
-        messageLabel.textColor = UIColor(named: "EateryBlue")
+        imageView.tintColor = UIColor.Eatery.blue
+        messageLabel.textColor = UIColor.Eatery.blue
     }
 
 }

--- a/Eatery Blue/Eatery Blue/UI/Carousel/CarouselMoreEateriesView.swift
+++ b/Eatery Blue/Eatery Blue/UI/Carousel/CarouselMoreEateriesView.swift
@@ -25,7 +25,7 @@ class CarouselMoreEateriesView: UIView {
     }
 
     private func setUpSelf() {
-        backgroundColor = UIColor(named: "OffWhite")
+        backgroundColor = UIColor.Eatery.offWhite
         layer.cornerRadius = 8
 
         addSubview(stackView)
@@ -47,12 +47,12 @@ class CarouselMoreEateriesView: UIView {
 
     private func setUpImageView() {
         imageView.image = UIImage(named: "ButtonNext")?.withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = UIColor(named: "EateryBlue")
+        imageView.tintColor = UIColor.Eatery.blue
         imageView.contentMode = .scaleAspectFit
     }
 
     private func setUpTitleLabel() {
-        titleLabel.textColor = UIColor(named: "EateryBlue")
+        titleLabel.textColor = UIColor.Eatery.blue
         titleLabel.font = .preferredFont(for: .callout, weight: .semibold)
         titleLabel.text = "More eateries"
     }

--- a/Eatery Blue/Eatery Blue/UI/EateryCard/EateryCardAlertView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryCard/EateryCardAlertView.swift
@@ -27,7 +27,7 @@ class EateryCardAlertView: UIView {
     private func setUpSelf() {
         insetsLayoutMarginsFromSafeArea = false
         layoutMargins = UIEdgeInsets(top: 2, left: 12, bottom: 2, right: 12)
-        tintColor = UIColor(named: "EateryOrange")
+        tintColor = UIColor.Eatery.orange
         backgroundColor = .white
 
         addSubview(stackView)

--- a/Eatery Blue/Eatery Blue/UI/EateryCard/EateryCardVisualEffectView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryCard/EateryCardVisualEffectView.swift
@@ -41,7 +41,7 @@ class EateryCardVisualEffectView<Content: UIView>: UIView {
         container.cornerRadius = 8
         container.shadowRadius = 4
         container.shadowOffset = CGSize(width: 0, height: 4)
-        container.shadowColor = UIColor(named: "ShadowLight")
+        container.shadowColor = UIColor.Eatery.shadowLight
         container.shadowOpacity = 0.25
         addSubview(container)
     }

--- a/Eatery Blue/Eatery Blue/UI/EateryCard/EateryLargeCardContentView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryCard/EateryLargeCardContentView.swift
@@ -33,7 +33,7 @@ class EateryLargeCardContentView: UIView {
     private func setUpSelf() {
         insetsLayoutMarginsFromSafeArea = false
         layoutMargins = .zero
-        backgroundColor = UIColor(named: "OffWhite")
+        backgroundColor = UIColor.Eatery.offWhite
 
         addSubview(imageView)
         setUpImageView()
@@ -85,12 +85,12 @@ class EateryLargeCardContentView: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .body, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpSubtitleLabel(_ subtitleLabel: UILabel) {
         subtitleLabel.font = .preferredFont(for: .subheadline, weight: .medium)
-        subtitleLabel.textColor = UIColor(named: "Gray05")
+        subtitleLabel.textColor = UIColor.Eatery.gray05
     }
 
     private func setUpFavoriteImageView() {

--- a/Eatery Blue/Eatery Blue/UI/EateryCard/EateryMediumCardContentView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryCard/EateryMediumCardContentView.swift
@@ -29,7 +29,7 @@ class EateryMediumCardContentView: UIView {
     }
 
     private func setUpSelf() {
-        backgroundColor = UIColor(named: "OffWhite")
+        backgroundColor = UIColor.Eatery.offWhite
 
         addSubview(imageView)
         setUpImageView()
@@ -69,12 +69,12 @@ class EateryMediumCardContentView: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .body, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpSubtitleLabel() {
         subtitleLabel.font = .preferredFont(for: .subheadline, weight: .medium)
-        subtitleLabel.textColor = UIColor(named: "Gray05")
+        subtitleLabel.textColor = UIColor.Eatery.gray05
     }
 
     private func setUpFavoriteImageView() {

--- a/Eatery Blue/Eatery Blue/UI/EateryCard/EaterySmallCardView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryCard/EaterySmallCardView.swift
@@ -43,7 +43,7 @@ class EaterySmallCardView: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .subheadline, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
         titleLabel.numberOfLines = 2
         titleLabel.textAlignment = .center
     }

--- a/Eatery Blue/Eatery Blue/UI/EateryFilter/PillFilterButtonView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryFilter/PillFilterButtonView.swift
@@ -74,12 +74,12 @@ class PillFilterButtonView: UIView {
 
         if isHighlighted {
             label.textColor = .white
-            backgroundColor = UIColor(named: "Black")
+            backgroundColor = UIColor.Eatery.black
             imageView.tintColor = .white
         } else {
-            label.textColor = UIColor(named: "Black")
-            backgroundColor = UIColor(named: "Gray00")
-            imageView.tintColor = UIColor(named: "Black")
+            label.textColor = UIColor.Eatery.black
+            backgroundColor = UIColor.Eatery.gray00
+            imageView.tintColor = UIColor.Eatery.black
         }
     }
 

--- a/Eatery Blue/Eatery Blue/UI/EateryScreen/EateryNavigationView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryScreen/EateryNavigationView.swift
@@ -80,7 +80,7 @@ class EateryNavigationView: UIView {
 
     private func setUpBackButton() {
         backButton.content.image = UIImage(named: "ArrowLeft")
-        backButton.shadowColor = UIColor(named: "Black")
+        backButton.shadowColor = UIColor.Eatery.black
         backButton.shadowOffset = CGSize(width: 0, height: 4)
         backButton.backgroundColor = .white
         backButton.layoutMargins = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
@@ -88,13 +88,13 @@ class EateryNavigationView: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .systemFont(ofSize: 20, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
         titleLabel.textAlignment = .center
     }
 
     private func setUpFavoriteButton() {
         favoriteButton.content.image = UIImage(named: "FavoriteSelected")
-        favoriteButton.shadowColor = UIColor(named: "Black")
+        favoriteButton.shadowColor = UIColor.Eatery.black
         favoriteButton.shadowOffset = CGSize(width: 0, height: 4)
         favoriteButton.backgroundColor = .white
         favoriteButton.layoutMargins = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
@@ -112,7 +112,7 @@ class EateryNavigationView: UIView {
 
         setUpCategoriesStackView(categoriesForeground)
         categoriesForeground.isUserInteractionEnabled = false
-        categoriesForeground.backgroundColor = UIColor(named: "Black")
+        categoriesForeground.backgroundColor = UIColor.Eatery.black
 
         // Set some completely opaque color for the foregroundMask
         foregroundMask.backgroundColor = .white
@@ -211,7 +211,7 @@ class EateryNavigationView: UIView {
         backgroundContainer.layoutMargins = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
         foregroundContainer.layoutMargins = backgroundContainer.layoutMargins
 
-        backgroundContainer.content.textColor = UIColor(named: "Gray05")
+        backgroundContainer.content.textColor = UIColor.Eatery.gray05
         foregroundContainer.content.textColor = .white
 
         categoriesBackground.addArrangedSubview(backgroundContainer)

--- a/Eatery Blue/Eatery Blue/UI/EateryScreen/EateryViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryScreen/EateryViewController.swift
@@ -52,7 +52,7 @@ class EateryViewController: UIViewController {
     }
 
     private func setUpScrollView() {
-        scrollView.backgroundColor = UIColor(named: "Gray00")
+        scrollView.backgroundColor = UIColor.Eatery.gray00
         scrollView.alwaysBounceVertical = true
         scrollView.contentInsetAdjustmentBehavior = .never
         scrollView.scrollIndicatorInsets = .zero
@@ -132,7 +132,7 @@ class EateryViewController: UIViewController {
         if paymentMethods.contains(.mealSwipes) {
             let imageView = UIImageView()
             imageView.image = UIImage(named: "MealSwipes")?.withRenderingMode(.alwaysTemplate)
-            imageView.tintColor = UIColor(named: "EateryBlue")
+            imageView.tintColor = UIColor.Eatery.blue
             imageView.contentMode = .scaleAspectFit
 
             imageView.snp.makeConstraints { make in
@@ -145,7 +145,7 @@ class EateryViewController: UIViewController {
         if paymentMethods.contains(.brbs) {
             let imageView = UIImageView()
             imageView.image = UIImage(named: "BRBs")?.withRenderingMode(.alwaysTemplate)
-            imageView.tintColor = UIColor(named: "EateryRed")
+            imageView.tintColor = UIColor.Eatery.red
             imageView.contentMode = .scaleAspectFit
 
             imageView.snp.makeConstraints { make in
@@ -158,7 +158,7 @@ class EateryViewController: UIViewController {
         if paymentMethods.contains(.cash), paymentMethods.contains(.credit) {
             let imageView = UIImageView()
             imageView.image = UIImage(named: "Cash")?.withRenderingMode(.alwaysTemplate)
-            imageView.tintColor = UIColor(named: "EateryGreen")
+            imageView.tintColor = UIColor.Eatery.green
             imageView.contentMode = .scaleAspectFit
             
             imageView.snp.makeConstraints { make in
@@ -176,7 +176,7 @@ class EateryViewController: UIViewController {
 
         container.layoutMargins = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
         container.cornerRadiusView.backgroundColor = .white
-        container.shadowColor = UIColor(named: "Black")
+        container.shadowColor = UIColor.Eatery.black
         container.shadowOffset = CGSize(width: 0, height: 4)
         container.shadowOpacity = 0.25
         container.shadowRadius = 4
@@ -201,7 +201,7 @@ class EateryViewController: UIViewController {
 
         let imageView = UIImageView()
         imageView.image = UIImage(named: "Place")?.withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = UIColor(named: "Gray05")
+        imageView.tintColor = UIColor.Eatery.gray05
 
         let container = ContainerView(pillContent: imageView)
         container.cornerRadiusView.backgroundColor = .white
@@ -220,7 +220,7 @@ class EateryViewController: UIViewController {
         let label = UILabel()
         label.text = name
         label.font = .preferredFont(for: .largeTitle, weight: .semibold)
-        label.textColor = UIColor(named: "Black")
+        label.textColor = UIColor.Eatery.black
 
         let container = ContainerView(content: label)
         container.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
@@ -230,7 +230,7 @@ class EateryViewController: UIViewController {
     func addShortDescriptionLabel(_ eatery: Eatery) {
         let label = UILabel()
         label.text = "\(eatery.locationDescription ?? "--") · \(eatery.menuSummary ?? "--")"
-        label.textColor = UIColor(named: "Gray05")
+        label.textColor = UIColor.Eatery.gray05
         label.font = .preferredFont(for: .subheadline, weight: .semibold)
 
         let container = ContainerView(content: label)
@@ -251,7 +251,7 @@ class EateryViewController: UIViewController {
         if let orderOnlineAction = orderOnlineAction {
             let content = PillButtonView()
             content.layoutMargins = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
-            content.backgroundColor = UIColor(named: "EateryBlue")
+            content.backgroundColor = UIColor.Eatery.blue
             content.imageView.image = UIImage(named: "iPhone")
             content.imageView.tintColor = .white
             content.titleLabel.textColor = .white
@@ -267,10 +267,10 @@ class EateryViewController: UIViewController {
         if let directionsAction = directionsAction {
             let content = PillButtonView()
             content.layoutMargins = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
-            content.backgroundColor = UIColor(named: "Gray00")
+            content.backgroundColor = UIColor.Eatery.gray00
             content.imageView.image = UIImage(named: "Walk")?.withRenderingMode(.alwaysTemplate)
-            content.imageView.tintColor = UIColor(named: "Black")
-            content.titleLabel.textColor = UIColor(named: "Black")
+            content.imageView.tintColor = UIColor.Eatery.black
+            content.titleLabel.textColor = UIColor.Eatery.black
             content.titleLabel.text = "Get directions"
 
             let button = ButtonView(content: content)
@@ -312,7 +312,7 @@ class EateryViewController: UIViewController {
         let cell = TimingCellView()
         cell.layoutMargins = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
 
-        cell.titleLabel.textColor = UIColor(named: "Gray05")
+        cell.titleLabel.textColor = UIColor.Eatery.gray05
         let text = NSMutableAttributedString()
         text.append(NSAttributedString(
             attachment: NSTextAttachment(image: UIImage(named: "Clock"), scaledToMatch: cell.titleLabel.font))
@@ -336,7 +336,7 @@ class EateryViewController: UIViewController {
         let cell = TimingCellView()
         cell.layoutMargins = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
 
-        cell.titleLabel.textColor = UIColor(named: "Gray05")
+        cell.titleLabel.textColor = UIColor.Eatery.gray05
         let text = NSMutableAttributedString()
         text.append(NSAttributedString(
             attachment: NSTextAttachment(image: UIImage(named: "Watch"), scaledToMatch: cell.titleLabel.font))
@@ -345,7 +345,7 @@ class EateryViewController: UIViewController {
         cell.titleLabel.attributedText = text
 
         if let waitTimes = eatery.waitTimesByDay[Day()], let sample = waitTimes.sample(at: Date()) {
-            cell.statusLabel.textColor = UIColor(named: "Black")
+            cell.statusLabel.textColor = UIColor.Eatery.black
             let low = Int(round(sample.low / 60))
             let high = Int(round(sample.high / 60))
             cell.statusLabel.text = "\(low)-\(high) minutes"
@@ -359,14 +359,14 @@ class EateryViewController: UIViewController {
             }
 
         } else {
-            cell.statusLabel.textColor = UIColor(named: "Gray05")
+            cell.statusLabel.textColor = UIColor.Eatery.gray05
             cell.statusLabel.text = "-- minutes"
         }
 
         return cell
     }
 
-    func addSpacer(height: CGFloat, color: UIColor? = UIColor(named: "Gray00")) {
+    func addSpacer(height: CGFloat, color: UIColor? = UIColor.Eatery.gray00) {
         let spacer = UIView()
         spacer.backgroundColor = color
         stackView.addArrangedSubview(spacer)
@@ -375,7 +375,7 @@ class EateryViewController: UIViewController {
         }
     }
 
-    func addViewProportionalSpacer(multiplier: CGFloat, color: UIColor? = UIColor(named: "Gray00")) {
+    func addViewProportionalSpacer(multiplier: CGFloat, color: UIColor? = UIColor.Eatery.gray00) {
         let spacer = UIView()
         spacer.backgroundColor = color
         stackView.addArrangedSubview(spacer)

--- a/Eatery Blue/Eatery Blue/UI/EateryScreen/MenuCategoryView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryScreen/MenuCategoryView.swift
@@ -32,7 +32,7 @@ class MenuCategoryView: UIView {
     }
 
     private func setUpTitleLabel() {
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
         titleLabel.font = .preferredFont(for: .body, weight: .semibold)
     }
 

--- a/Eatery Blue/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
@@ -37,12 +37,12 @@ class MenuHeaderView: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .title2, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpSubtitleLabel() {
         subtitleLabel.font = .preferredFont(for: .subheadline, weight: .semibold)
-        subtitleLabel.textColor = UIColor(named: "Gray05")
+        subtitleLabel.textColor = UIColor.Eatery.gray05
     }
 
     private func setUpButtonImageView() {

--- a/Eatery Blue/Eatery Blue/UI/EateryScreen/MenuItemView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryScreen/MenuItemView.swift
@@ -53,17 +53,17 @@ class MenuItemView: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .subheadline, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpPriceLabel() {
         priceLabel.font = .preferredFont(for: .subheadline, weight: .regular)
-        priceLabel.textColor = UIColor(named: "Gray05")
+        priceLabel.textColor = UIColor.Eatery.gray05
     }
 
     private func setUpDescriptionLabel() {
         descriptionLabel.font = .preferredFont(for: .footnote, weight: .regular)
-        descriptionLabel.textColor = UIColor(named: "Gray05")
+        descriptionLabel.textColor = UIColor.Eatery.gray05
         descriptionLabel.isHidden = true
         descriptionLabel.numberOfLines = 0
     }

--- a/Eatery Blue/Eatery Blue/UI/EateryScreen/TimingDataView.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryScreen/TimingDataView.swift
@@ -29,7 +29,7 @@ class TimingDataView: UIView {
 
     private func setUpStackView() {
         stackView.layer.borderWidth = 1
-        stackView.layer.borderColor = UIColor(named: "Gray00")?.cgColor
+        stackView.layer.borderColor = UIColor.Eatery.gray00.cgColor
         stackView.layer.cornerRadius = 8
 
         stackView.axis = .horizontal

--- a/Eatery Blue/Eatery Blue/UI/HomeScreen/HomeNavigationView.swift
+++ b/Eatery Blue/Eatery Blue/UI/HomeScreen/HomeNavigationView.swift
@@ -26,7 +26,7 @@ class HomeNavigationView: NavigationView {
     }
 
     private func setUpSelf() {
-        backgroundColor = UIColor(named: "EateryBlue")
+        backgroundColor = UIColor.Eatery.blue
         layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16)
 
         titleLabel.text = "Eatery"

--- a/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/HomeSearchEmptyModelController.swift
+++ b/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/HomeSearchEmptyModelController.swift
@@ -111,7 +111,7 @@ class HomeSearchEmptyModelController: HomeSearchEmptyViewController {
             default:
                 itemView.imageView.image = UIImage(named: "Place")?.withRenderingMode(.alwaysTemplate)
             }
-            itemView.imageView.tintColor = UIColor(named: "EateryBlue")
+            itemView.imageView.tintColor = UIColor.Eatery.blue
             itemView.titleLabel.text = recentSearch.title
 
             if let subtitle = recentSearch.subtitle {

--- a/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/SearchItemView.swift
+++ b/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/SearchItemView.swift
@@ -59,24 +59,24 @@ class SearchItemView: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .subheadline, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpPriceLabel() {
         priceLabel.font = .preferredFont(for: .subheadline, weight: .regular)
-        priceLabel.textColor = UIColor(named: "Gray05")
+        priceLabel.textColor = UIColor.Eatery.gray05
     }
 
     private func setUpDescriptionLabel() {
         descriptionLabel.font = .preferredFont(for: .footnote, weight: .regular)
-        descriptionLabel.textColor = UIColor(named: "Gray05")
+        descriptionLabel.textColor = UIColor.Eatery.gray05
         descriptionLabel.isHidden = true
         descriptionLabel.numberOfLines = 0
     }
 
     private func setUpSourceLabel() {
         sourceLabel.font = .preferredFont(for: .caption1, weight: .medium)
-        sourceLabel.textColor = UIColor(named: "EateryBlue")
+        sourceLabel.textColor = UIColor.Eatery.blue
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/SearchRecentItemView.swift
+++ b/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/SearchRecentItemView.swift
@@ -35,7 +35,7 @@ class SearchRecentItemView: UIView {
 
     private func setUpImageView() {
         imageView.contentMode = .scaleAspectFit
-        imageView.tintColor = UIColor(named: "EateryBlue")
+        imageView.tintColor = UIColor.Eatery.blue
     }
 
     private func setUpStackView() {
@@ -51,12 +51,12 @@ class SearchRecentItemView: UIView {
     }
 
     private func setUpTitleLabel() {
-        titleLabel.textColor = UIColor(named: "EateryBlue")
+        titleLabel.textColor = UIColor.Eatery.blue
         titleLabel.font = .preferredFont(for: .body, weight: .medium)
     }
 
     private func setUpSubtitleLabel() {
-        subtitleLabel.textColor = UIColor(named: "Gray05")
+        subtitleLabel.textColor = UIColor.Eatery.gray05
         subtitleLabel.font = .preferredFont(for: .caption1, weight: .medium)
     }
 

--- a/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/SearchRecentsView.swift
+++ b/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/SearchRecentsView.swift
@@ -32,7 +32,7 @@ class SearchRecentsView: UIView {
     }
 
     private func setUpTitleLabel() {
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
         titleLabel.font = .preferredFont(for: .title2, weight: .semibold)
         titleLabel.text = "Recent Searches"
     }

--- a/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/SearchResultsCountView.swift
+++ b/Eatery Blue/Eatery Blue/UI/HomeSearchScreen/SearchResultsCountView.swift
@@ -41,8 +41,8 @@ class SearchResultsCountView: UIView {
         resetButton.layoutMargins = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
         resetButton.content.font = .preferredFont(for: .footnote, weight: .semibold)
         resetButton.content.text = "Reset"
-        resetButton.content.textColor = UIColor(named: "Black")
-        resetButton.backgroundColor = UIColor(named: "Gray00")
+        resetButton.content.textColor = UIColor.Eatery.black
+        resetButton.backgroundColor = UIColor.Eatery.gray00
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/ListScreen/ListNavigationView.swift
+++ b/Eatery Blue/Eatery Blue/UI/ListScreen/ListNavigationView.swift
@@ -74,7 +74,7 @@ class ListNavigationView: UIView {
 
     private func setUpBackButton() {
         backButton.content.image = UIImage(named: "ArrowLeft")?.withRenderingMode(.alwaysTemplate)
-        backButton.content.tintColor = UIColor(named: "Black")
+        backButton.content.tintColor = UIColor.Eatery.black
         backButton.content.contentMode = .scaleAspectFit
     }
 
@@ -85,12 +85,12 @@ class ListNavigationView: UIView {
 
     private func setUpSearchButton() {
         searchButton.content.image = UIImage(named: "Search")?.withRenderingMode(.alwaysTemplate)
-        searchButton.content.tintColor = UIColor(named: "Black")
+        searchButton.content.tintColor = UIColor.Eatery.black
         searchButton.content.contentMode = .scaleAspectFit
     }
 
     private func setUpSeparator() {
-        separator.backgroundColor = UIColor(named: "Gray01")
+        separator.backgroundColor = UIColor.Eatery.gray01
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/ListScreen/ListViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/ListScreen/ListViewController.swift
@@ -152,7 +152,7 @@ class ListViewController: UIViewController {
         let label = UILabel()
         label.text = title
         label.font = .systemFont(ofSize: 34, weight: .bold)
-        label.textColor = UIColor(named: "EateryBlue")
+        label.textColor = UIColor.Eatery.blue
 
         let container = ContainerView(content: label)
         container.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
@@ -164,7 +164,7 @@ class ListViewController: UIViewController {
         label.text = description
         label.numberOfLines = 0
         label.font = .preferredFont(for: .body, weight: .medium)
-        label.textColor = UIColor(named: "Gray06")
+        label.textColor = UIColor.Eatery.gray06
 
         let container = ContainerView(content: label)
         container.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)

--- a/Eatery Blue/Eatery Blue/UI/Login/LoginView.swift
+++ b/Eatery Blue/Eatery Blue/UI/Login/LoginView.swift
@@ -45,7 +45,7 @@ class LoginView: UIView {
         let titleLabel = UILabel()
         titleLabel.text = text
         titleLabel.font = .systemFont(ofSize: 34, weight: .bold)
-        titleLabel.textColor = UIColor(named: "EateryBlue")
+        titleLabel.textColor = UIColor.Eatery.blue
 
         stackView.addArrangedSubview(titleLabel)
     }
@@ -54,7 +54,7 @@ class LoginView: UIView {
         let subtitleLabel = UILabel()
         subtitleLabel.text = text
         subtitleLabel.font = .preferredFont(for: .body, weight: .medium)
-        subtitleLabel.textColor = UIColor(named: "Gray06")
+        subtitleLabel.textColor = UIColor.Eatery.gray06
 
         stackView.addArrangedSubview(subtitleLabel)
     }
@@ -63,14 +63,14 @@ class LoginView: UIView {
         let titleLabel = UILabel()
         titleLabel.text = title
         titleLabel.font = .preferredFont(for: .body, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
 
         stackView.addArrangedSubview(titleLabel)
     }
 
     func addTextField(_ textField: UITextField) {
         let container = ContainerView(content: textField)
-        container.backgroundColor = UIColor(named: "Gray00")
+        container.backgroundColor = UIColor.Eatery.gray00
         container.cornerRadius = 8
         container.layoutMargins = UIEdgeInsets(top: 10, left: 8, bottom: 10, right: 8)
         container.tap { _ in

--- a/Eatery Blue/Eatery Blue/UI/MenuPickerSheet/MenuChoiceView.swift
+++ b/Eatery Blue/Eatery Blue/UI/MenuPickerSheet/MenuChoiceView.swift
@@ -37,12 +37,12 @@ class MenuChoiceView: UIView {
 
     private func setUpDescriptionLabel() {
         descriptionLabel.font = .preferredFont(for: .body, weight: .semibold)
-        descriptionLabel.textColor = UIColor(named: "Black")
+        descriptionLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpTimeLabel() {
         timeLabel.font = .preferredFont(for: .caption1, weight: .semibold)
-        timeLabel.textColor = UIColor(named: "Gray05")
+        timeLabel.textColor = UIColor.Eatery.gray05
     }
 
     private func setUpImageView() {

--- a/Eatery Blue/Eatery Blue/UI/MenuPickerSheet/MenuDayPickerCell.swift
+++ b/Eatery Blue/Eatery Blue/UI/MenuPickerSheet/MenuDayPickerCell.swift
@@ -33,7 +33,7 @@ class MenuDayPickerCell: UIView {
 
     private func setUpWeekdayLabel() {
         weekdayLabel.font = .preferredFont(for: .caption1, weight: .semibold)
-        weekdayLabel.textColor = UIColor(named: "Gray05")
+        weekdayLabel.textColor = UIColor.Eatery.gray05
         weekdayLabel.textAlignment = .center
     }
 

--- a/Eatery Blue/Eatery Blue/UI/MenuPickerSheet/MenuPickerSheetViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/MenuPickerSheet/MenuPickerSheetViewController.swift
@@ -111,23 +111,23 @@ class MenuPickerSheetViewController: SheetViewController {
             if isToday {
                 if isSelected {
                     cell.dayLabel.content.textColor = .white
-                    cell.dayLabel.cornerRadiusView.backgroundColor = UIColor(named: "EateryBlue")
+                    cell.dayLabel.cornerRadiusView.backgroundColor = UIColor.Eatery.blue
                 } else if isDisabled {
-                    cell.dayLabel.content.textColor = UIColor(named: "EateryBlueMedium")
+                    cell.dayLabel.content.textColor = UIColor.Eatery.blueMedium
                     cell.dayLabel.cornerRadiusView.backgroundColor = nil
                 } else {
-                    cell.dayLabel.content.textColor = UIColor(named: "EateryBlue")
+                    cell.dayLabel.content.textColor = UIColor.Eatery.blue
                     cell.dayLabel.cornerRadiusView.backgroundColor = nil
                 }
             } else {
                 if isSelected {
                     cell.dayLabel.content.textColor = .white
-                    cell.dayLabel.cornerRadiusView.backgroundColor = UIColor(named: "Black")
+                    cell.dayLabel.cornerRadiusView.backgroundColor = UIColor.Eatery.black
                 } else if isDisabled {
-                    cell.dayLabel.content.textColor = UIColor(named: "Gray03")
+                    cell.dayLabel.content.textColor = UIColor.Eatery.gray03
                     cell.dayLabel.cornerRadiusView.backgroundColor = nil
                 } else {
-                    cell.dayLabel.content.textColor = UIColor(named: "Black")
+                    cell.dayLabel.content.textColor = UIColor.Eatery.black
                     cell.dayLabel.cornerRadiusView.backgroundColor = nil
                 }
             }

--- a/Eatery Blue/Eatery Blue/UI/Onboarding/OnboardingFeatureView.swift
+++ b/Eatery Blue/Eatery Blue/UI/Onboarding/OnboardingFeatureView.swift
@@ -37,12 +37,12 @@ class OnboardingFeatureView: UIView {
 
     private func setUpTitleLabel() {
         titleLabel.font = .systemFont(ofSize: 34, weight: .bold)
-        titleLabel.textColor = UIColor(named: "EateryBlue")
+        titleLabel.textColor = UIColor.Eatery.blue
     }
 
     private func setUpSubtitleLabel() {
         subtitleLabel.font = .preferredFont(for: .body, weight: .medium)
-        subtitleLabel.textColor = UIColor(named: "Gray06")
+        subtitleLabel.textColor = UIColor.Eatery.gray06
     }
 
     private func setUpImageView() {

--- a/Eatery Blue/Eatery Blue/UI/Onboarding/OnboardingFeaturesViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/Onboarding/OnboardingFeaturesViewController.swift
@@ -66,7 +66,7 @@ class OnboardingFeaturesViewController: UIViewController {
 
     private func setUpBackButton() {
         backButton.content.image = UIImage(named: "ArrowLeft")?.withRenderingMode(.alwaysTemplate)
-        backButton.content.tintColor = UIColor(named: "Black")
+        backButton.content.tintColor = UIColor.Eatery.black
         backButton.content.contentMode = .scaleAspectFit
         backButton.layoutMargins = UIEdgeInsets(top: 5, left: 0, bottom: 5, right: 0)
 
@@ -91,10 +91,10 @@ class OnboardingFeaturesViewController: UIViewController {
 
     private func setUpNextButton() {
         nextButton.content.text = "Next"
-        nextButton.content.textColor = UIColor(named: "EateryBlack")
+        nextButton.content.textColor = UIColor.Eatery.black
         nextButton.content.font = .preferredFont(for: .body, weight: .semibold)
         nextButton.content.textAlignment = .center
-        nextButton.backgroundColor = UIColor(named: "Gray00")
+        nextButton.backgroundColor = UIColor.Eatery.gray00
         nextButton.layoutMargins = UIEdgeInsets(top: 14, left: 16, bottom: 14, right: 16)
 
         nextButton.buttonPress { [self] _ in

--- a/Eatery Blue/Eatery Blue/UI/Onboarding/OnboardingLoginViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/Onboarding/OnboardingLoginViewController.swift
@@ -50,7 +50,7 @@ class OnboardingLoginViewController: UIViewController {
 
     private func setUpBackButton() {
         backButton.content.image = UIImage(named: "ArrowLeft")?.withRenderingMode(.alwaysTemplate)
-        backButton.content.tintColor = UIColor(named: "Black")
+        backButton.content.tintColor = UIColor.Eatery.black
         backButton.content.contentMode = .scaleAspectFit
         backButton.layoutMargins = UIEdgeInsets(top: 5, left: 0, bottom: 5, right: 0)
 
@@ -170,10 +170,10 @@ class OnboardingLoginViewController: UIViewController {
     func setLoginButtonEnabled(_ isEnabled: Bool) {
         if isEnabled {
             loginButton.content.textColor = .white
-            loginButton.backgroundColor = UIColor(named: "EateryBlue")
+            loginButton.backgroundColor = UIColor.Eatery.blue
         } else {
-            loginButton.content.textColor = UIColor(named: "EateryBlack")
-            loginButton.backgroundColor = UIColor(named: "Gray00")
+            loginButton.content.textColor = UIColor.Eatery.black
+            loginButton.backgroundColor = UIColor.Eatery.gray00
         }
     }
 

--- a/Eatery Blue/Eatery Blue/UI/Onboarding/OnboardingStartViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/Onboarding/OnboardingStartViewController.swift
@@ -39,12 +39,12 @@ class OnboardingStartViewController: UIViewController {
 
     private func setUpEateryLogoView() {
         eateryLogoView.image = UIImage(named: "Eatery")?.withRenderingMode(.alwaysTemplate)
-        eateryLogoView.tintColor = UIColor(named: "EateryBlue")
+        eateryLogoView.tintColor = UIColor.Eatery.blue
     }
 
     private func setUpTitleLabel() {
         titleLabel.text = "Eatery"
-        titleLabel.textColor = UIColor(named: "EateryBlue")
+        titleLabel.textColor = UIColor.Eatery.blue
         titleLabel.font = .systemFont(ofSize: 48, weight: .bold)
     }
 
@@ -58,7 +58,7 @@ class OnboardingStartViewController: UIViewController {
         nextButton.cornerRadius = 8
         nextButton.shadowRadius = 4
         nextButton.shadowOffset = CGSize(width: 0, height: 4)
-        nextButton.shadowColor = UIColor(named: "ShadowLight")
+        nextButton.shadowColor = UIColor.Eatery.shadowLight
         nextButton.shadowOpacity = 0.25
         nextButton.layoutMargins = UIEdgeInsets(top: 14, left: 16, bottom: 14, right: 16)
 
@@ -70,7 +70,7 @@ class OnboardingStartViewController: UIViewController {
 
     private func setUpAppDevLogoView() {
         appDevLogoView.image = UIImage(named: "AppDev")?.withRenderingMode(.alwaysTemplate)
-        appDevLogoView.tintColor = UIColor(named: "Gray03")
+        appDevLogoView.tintColor = UIColor.Eatery.gray03
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/PaymentMethodsFilterSheet/PaymentMethodsFilterSheetViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/PaymentMethodsFilterSheet/PaymentMethodsFilterSheetViewController.swift
@@ -121,26 +121,26 @@ class PaymentMethodsFilterSheetViewController: SheetViewController {
 
         if selectedPaymentMethods.contains(.mealSwipes) {
             mealSwipesView.imageView.image = UIImage(named: "MealSwipesSelected")
-            mealSwipesView.label.textColor = UIColor(named: "EateryBlue")
+            mealSwipesView.label.textColor = UIColor.Eatery.blue
         } else {
             mealSwipesView.imageView.image = UIImage(named: "MealSwipesUnselected")
-            mealSwipesView.label.textColor = UIColor(named: "Gray05")
+            mealSwipesView.label.textColor = UIColor.Eatery.gray05
         }
 
         if selectedPaymentMethods.contains(.brbs) {
             brbsView.imageView.image = UIImage(named: "BRBsSelected")
-            brbsView.label.textColor = UIColor(named: "EateryRed")
+            brbsView.label.textColor = UIColor.Eatery.red
         } else {
             brbsView.imageView.image = UIImage(named: "BRBsUnselected")
-            brbsView.label.textColor = UIColor(named: "Gray05")
+            brbsView.label.textColor = UIColor.Eatery.gray05
         }
 
         if selectedPaymentMethods.contains(.cash), selectedPaymentMethods.contains(.credit) {
             cashOrCreditView.imageView.image = UIImage(named: "CashSelected")
-            cashOrCreditView.label.textColor = UIColor(named: "EateryGreen")
+            cashOrCreditView.label.textColor = UIColor.Eatery.green
         } else {
             cashOrCreditView.imageView.image = UIImage(named: "CashUnselected")
-            cashOrCreditView.label.textColor = UIColor(named: "Gray05")
+            cashOrCreditView.label.textColor = UIColor.Eatery.gray05
         }
     }
 

--- a/Eatery Blue/Eatery Blue/UI/PaymentMethodsSheet/PaymentMethodsSheetViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/PaymentMethodsSheet/PaymentMethodsSheetViewController.swift
@@ -77,16 +77,16 @@ class PaymentMethodsSheetViewController: SheetViewController {
         self.paymentMethods = paymentMethods
 
         mealSwipesImageView.tintColor = paymentMethods.contains(.mealSwipes)
-            ? UIColor(named: "EateryBlue")
-            : UIColor(named: "Gray05")
+            ? UIColor.Eatery.blue
+            : UIColor.Eatery.gray05
 
         brbsImageView.tintColor = paymentMethods.contains(.brbs)
-            ? UIColor(named: "EateryRed")
-            : UIColor(named: "Gray05")
+            ? UIColor.Eatery.red
+            : UIColor.Eatery.gray05
 
         cashOrCardImageView.tintColor = paymentMethods.contains(.cash) && paymentMethods.contains(.credit)
-            ? UIColor(named: "EateryGreen")
-            : UIColor(named: "Gray05")
+            ? UIColor.Eatery.green
+            : UIColor.Eatery.gray05
 
         descriptionLabel.attributedText = getAttributedString(paymentMethods)
     }
@@ -137,7 +137,7 @@ class PaymentMethodsSheetViewController: SheetViewController {
             attributedString.append(NSAttributedString(attachment: attachment))
             attributedString.append(NSAttributedString(string: " Meal swipes"))
             attributedString.addAttributes(
-                [.foregroundColor: UIColor(named: "EateryBlue") as Any],
+                [.foregroundColor: UIColor.Eatery.blue as Any],
                 range: NSRange(location: 0, length: attributedString.length)
             )
             result.append(attributedString)
@@ -152,7 +152,7 @@ class PaymentMethodsSheetViewController: SheetViewController {
             attributedString.append(NSAttributedString(attachment: attachment))
             attributedString.append(NSAttributedString(string: " BRBs"))
             attributedString.addAttributes(
-                [.foregroundColor: UIColor(named: "EateryRed") as Any],
+                [.foregroundColor: UIColor.Eatery.red as Any],
                 range: NSRange(location: 0, length: attributedString.length)
             )
             result.append(attributedString)
@@ -167,7 +167,7 @@ class PaymentMethodsSheetViewController: SheetViewController {
             attributedString.append(NSAttributedString(attachment: attachment))
             attributedString.append(NSAttributedString(string: " Cash or credit"))
             attributedString.addAttributes(
-                [.foregroundColor: UIColor(named: "EateryGreen") as Any],
+                [.foregroundColor: UIColor.Eatery.green as Any],
                 range: NSRange(location: 0, length: attributedString.length)
             )
             result.append(attributedString)

--- a/Eatery Blue/Eatery Blue/UI/Profile/ProfileLoginViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/Profile/ProfileLoginViewController.swift
@@ -36,11 +36,11 @@ class ProfileLoginViewController: UIViewController {
     private func setUpNavigationItem() {
         let appearance = UINavigationBarAppearance()
         appearance.titleTextAttributes = [
-            .foregroundColor: UIColor(named: "Black") as Any,
+            .foregroundColor: UIColor.Eatery.black as Any,
             .font: UIFont.eateryNavigationBarTitleFont
         ]
         appearance.largeTitleTextAttributes = [
-            .foregroundColor: UIColor(named: "EateryBlue") as Any,
+            .foregroundColor: UIColor.Eatery.blue as Any,
             .font: UIFont.eateryNavigationBarLargeTitleFont
         ]
 
@@ -60,7 +60,7 @@ class ProfileLoginViewController: UIViewController {
             target: self,
             action: #selector(didTapSettingsButton)
         )
-        settingsItem.tintColor = UIColor(named: "Black")
+        settingsItem.tintColor = UIColor.Eatery.black
         navigationItem.rightBarButtonItem = settingsItem
     }
 
@@ -164,10 +164,10 @@ class ProfileLoginViewController: UIViewController {
     func setLoginButtonEnabled(_ isEnabled: Bool) {
         if isEnabled {
             loginButton.content.textColor = .white
-            loginButton.backgroundColor = UIColor(named: "EateryBlue")
+            loginButton.backgroundColor = UIColor.Eatery.blue
         } else {
-            loginButton.content.textColor = UIColor(named: "EateryBlack")
-            loginButton.backgroundColor = UIColor(named: "Gray00")
+            loginButton.content.textColor = UIColor.Eatery.black
+            loginButton.backgroundColor = UIColor.Eatery.gray00
         }
     }
 

--- a/Eatery Blue/Eatery Blue/UI/ReportIssueScreen/IssueDescriptionView.swift
+++ b/Eatery Blue/Eatery Blue/UI/ReportIssueScreen/IssueDescriptionView.swift
@@ -24,7 +24,7 @@ class IssueDescriptionView: UIView {
     }
 
     private func setUpSelf() {
-        backgroundColor = UIColor(named: "Gray00")
+        backgroundColor = UIColor.Eatery.gray00
         layer.cornerRadius = 8
 
         addSubview(textView)
@@ -36,7 +36,7 @@ class IssueDescriptionView: UIView {
 
     private func setUpTextView() {
         textView.backgroundColor = .clear
-        textView.textColor = UIColor(named: "Black")
+        textView.textColor = UIColor.Eatery.black
         textView.font = .preferredFont(for: .subheadline, weight: .medium)
         textView.textContainerInset = UIEdgeInsets(top: 8, left: 0, bottom: 8, right: 0)
         textView.textContainer.lineFragmentPadding = 0
@@ -44,7 +44,7 @@ class IssueDescriptionView: UIView {
 
     private func setUpPlaceholderLabel() {
         placeholderLabel.text = "Tell us what's wrong..."
-        placeholderLabel.textColor = UIColor(named: "Gray05")
+        placeholderLabel.textColor = UIColor.Eatery.gray05
         placeholderLabel.font = .preferredFont(for: .subheadline, weight: .medium)
     }
 

--- a/Eatery Blue/Eatery Blue/UI/ReportIssueScreen/IssueTypeButtonView.swift
+++ b/Eatery Blue/Eatery Blue/UI/ReportIssueScreen/IssueTypeButtonView.swift
@@ -24,7 +24,7 @@ class IssueTypeButtonView: UIView {
     }
 
     private func setUpSelf() {
-        backgroundColor = UIColor(named: "Gray00")
+        backgroundColor = UIColor.Eatery.gray00
         layer.cornerRadius = 8
 
         addSubview(label)
@@ -40,7 +40,7 @@ class IssueTypeButtonView: UIView {
 
     private func setUpImageView() {
         imageView.image = UIImage(named: "ChevronDown")?.withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = UIColor(named: "Gray05")
+        imageView.tintColor = UIColor.Eatery.gray05
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/ReportIssueScreen/ReportIssueViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/ReportIssueScreen/ReportIssueViewController.swift
@@ -84,7 +84,7 @@ class ReportIssueViewController: UIViewController {
         let titleLabel = UILabel()
         header.addArrangedSubview(titleLabel)
         titleLabel.font = .preferredFont(for: .title2, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
         titleLabel.text = "Report an issue"
 
         let cancelButton = UIImageView()
@@ -124,7 +124,7 @@ class ReportIssueViewController: UIViewController {
     private func addHeader(title: String) {
         let label = UILabel()
         label.font = .preferredFont(for: .subheadline, weight: .semibold)
-        label.textColor = UIColor(named: "Black")
+        label.textColor = UIColor.Eatery.black
         label.text = title
         stackView.addArrangedSubview(label)
     }
@@ -152,12 +152,12 @@ class ReportIssueViewController: UIViewController {
     private func updateIssueTypeButtonFromState() {
         if let selectedIssueType = selectedIssueType {
             issueTypeButton.label.text = selectedIssueType.description
-            issueTypeButton.label.textColor = UIColor(named: "Black")
+            issueTypeButton.label.textColor = UIColor.Eatery.black
             issueTypeButton.label.font = .preferredFont(for: .subheadline, weight: .medium)
 
         } else {
             issueTypeButton.label.text = "Choose an option..."
-            issueTypeButton.label.textColor = UIColor(named: "Gray05")
+            issueTypeButton.label.textColor = UIColor.Eatery.gray05
             issueTypeButton.label.font = .preferredFont(for: .subheadline, weight: .medium)
         }
     }
@@ -181,11 +181,11 @@ class ReportIssueViewController: UIViewController {
 
     private func updateSubmitButtonFromState() {
         if submitEnabled {
-            submitButton.cornerRadiusView.backgroundColor = UIColor(named: "EateryBlue")
+            submitButton.cornerRadiusView.backgroundColor = UIColor.Eatery.blue
             submitButton.content.textColor = .white
         } else {
-            submitButton.cornerRadiusView.backgroundColor = UIColor(named: "Gray00")
-            submitButton.content.textColor = UIColor(named: "Gray03")
+            submitButton.cornerRadiusView.backgroundColor = UIColor.Eatery.gray00
+            submitButton.content.textColor = UIColor.Eatery.gray03
         }
     }
 

--- a/Eatery Blue/Eatery Blue/UI/ReportIssueView/ReportIssueButtonView.swift
+++ b/Eatery Blue/Eatery Blue/UI/ReportIssueView/ReportIssueButtonView.swift
@@ -25,7 +25,7 @@ class ReportIssueButtonView: UIView {
     }
 
     private func setUpSelf() {
-        backgroundColor = UIColor(named: "Gray00")
+        backgroundColor = UIColor.Eatery.gray00
         layoutMargins = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
 
         addSubview(container)
@@ -43,13 +43,13 @@ class ReportIssueButtonView: UIView {
     private func setUpImageView() {
         imageView.contentMode = .scaleAspectFit
         imageView.image = UIImage(named: "Report")?.withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = UIColor(named: "Black")
+        imageView.tintColor = UIColor.Eatery.black
     }
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .footnote, weight: .semibold)
         titleLabel.text = "Report an issue"
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/ReportIssueView/ReportIssueView.swift
+++ b/Eatery Blue/Eatery Blue/UI/ReportIssueView/ReportIssueView.swift
@@ -47,13 +47,13 @@ class ReportIssueView: UIView {
     }
 
     private func setUpTitleLabel() {
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
         titleLabel.font = .preferredFont(for: .body, weight: .semibold)
         titleLabel.text = "Make Eatery Better"
     }
 
     private func setUpDescriptionLabel() {
-        descriptionLabel.textColor = UIColor(named: "Gray05")
+        descriptionLabel.textColor = UIColor.Eatery.gray05
         descriptionLabel.font = .preferredFont(for: .footnote, weight: .regular)
         descriptionLabel.text = "Help us make this info more accurate by letting us know what's wrong."
         descriptionLabel.numberOfLines = 0

--- a/Eatery Blue/Eatery Blue/UI/SettingsAbout/SettingsAboutAppDevHeaderView.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsAbout/SettingsAboutAppDevHeaderView.swift
@@ -49,13 +49,13 @@ class SettingsAboutAppDevHeaderView: UIView {
 
     private func setUpLogoView() {
         logoView.image = UIImage(named: "AppDevLogo")?.withRenderingMode(.alwaysTemplate)
-        logoView.tintColor = UIColor(named: "Gray05")
+        logoView.tintColor = UIColor.Eatery.gray05
     }
 
     private func setUpSubtitleLabel() {
         subtitleLabel.text = "DESIGNED AND DEVELOPED BY"
         subtitleLabel.font = .preferredFont(for: .caption1, weight: .medium)
-        subtitleLabel.textColor = UIColor(named: "Gray05")
+        subtitleLabel.textColor = UIColor.Eatery.gray05
     }
 
     private func setUpTitleLabel() {
@@ -67,7 +67,7 @@ class SettingsAboutAppDevHeaderView: UIView {
             .font: UIFont.systemFont(ofSize: 36, weight: .semibold)
         ]))
         titleLabel.attributedText = attributedText
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/SettingsAbout/SettingsAboutMembersCarouselView.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsAbout/SettingsAboutMembersCarouselView.swift
@@ -71,7 +71,7 @@ class SettingsAboutMembersCarouselView: UIView {
 
         let container = ContainerView(pillContent: label)
         container.layoutMargins = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
-        container.backgroundColor = UIColor(named: "Gray00")
+        container.backgroundColor = UIColor.Eatery.gray00
 
         stackView.addArrangedSubview(container)
     }
@@ -79,7 +79,7 @@ class SettingsAboutMembersCarouselView: UIView {
     func addSeparator() {
         let imageView = UIImageView()
         imageView.image = UIImage(named: "FavoriteSelected")?.withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = UIColor(named: "Gray01")
+        imageView.tintColor = UIColor.Eatery.gray01
         imageView.snp.makeConstraints { make in
             make.width.height.equalTo(8)
         }

--- a/Eatery Blue/Eatery Blue/UI/SettingsAbout/SettingsAboutViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsAbout/SettingsAboutViewController.swift
@@ -41,11 +41,11 @@ class SettingsAboutViewController: UIViewController {
     private func setUpNavigationItem() {
         let appearance = UINavigationBarAppearance()
         appearance.titleTextAttributes = [
-            .foregroundColor: UIColor(named: "Black") as Any,
+            .foregroundColor: UIColor.Eatery.black as Any,
             .font: UIFont.eateryNavigationBarTitleFont
         ]
         appearance.largeTitleTextAttributes = [
-            .foregroundColor: UIColor(named: "EateryBlue") as Any,
+            .foregroundColor: UIColor.Eatery.blue as Any,
             .font: UIFont.eateryNavigationBarLargeTitleFont
         ]
 
@@ -65,7 +65,7 @@ class SettingsAboutViewController: UIViewController {
             target: self,
             action: #selector(didTapBackButton)
         )
-        backButton.tintColor = UIColor(named: "Black")
+        backButton.tintColor = UIColor.Eatery.black
         navigationItem.leftBarButtonItem = backButton
     }
 
@@ -87,7 +87,7 @@ class SettingsAboutViewController: UIViewController {
 
     private func setUpSubtitleLabel() {
         subtitleLabel.text = "Learn more about Cornell AppDev"
-        subtitleLabel.textColor = UIColor(named: "Gray06")
+        subtitleLabel.textColor = UIColor.Eatery.gray06
         subtitleLabel.font = .preferredFont(for: .body, weight: .medium)
     }
 
@@ -107,8 +107,8 @@ class SettingsAboutViewController: UIViewController {
         let pillView = websiteButton.content
         pillView.titleLabel.text = "Visit our website"
         pillView.imageView.image = UIImage(named: "Globe")?.withRenderingMode(.alwaysTemplate)
-        pillView.tintColor = UIColor(named: "Black")
-        pillView.backgroundColor = UIColor(named: "Gray00")
+        pillView.tintColor = UIColor.Eatery.black
+        pillView.backgroundColor = UIColor.Eatery.gray00
         pillView.layoutMargins = UIEdgeInsets(top: 12, left: 0, bottom: 12, right: 0)
 
         websiteButton.buttonPress { _ in

--- a/Eatery Blue/Eatery Blue/UI/SettingsFavorites/SettingsFavoritesViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsFavorites/SettingsFavoritesViewController.swift
@@ -35,11 +35,11 @@ class SettingsFavoritesViewController: UIViewController {
     private func setUpNavigationItem() {
         let appearance = UINavigationBarAppearance()
         appearance.titleTextAttributes = [
-            .foregroundColor: UIColor(named: "Black") as Any,
+            .foregroundColor: UIColor.Eatery.black as Any,
             .font: UIFont.eateryNavigationBarTitleFont
         ]
         appearance.largeTitleTextAttributes = [
-            .foregroundColor: UIColor(named: "EateryBlue") as Any,
+            .foregroundColor: UIColor.Eatery.blue as Any,
             .font: UIFont.eateryNavigationBarLargeTitleFont
         ]
 
@@ -59,7 +59,7 @@ class SettingsFavoritesViewController: UIViewController {
             target: self,
             action: #selector(didTapBackButton)
         )
-        backButton.tintColor = UIColor(named: "Black")
+        backButton.tintColor = UIColor.Eatery.black
         navigationItem.leftBarButtonItem = backButton
     }
 

--- a/Eatery Blue/Eatery Blue/UI/SettingsMain/SettingsLogoutPillButton.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsMain/SettingsLogoutPillButton.swift
@@ -24,7 +24,7 @@ class SettingsLogoutPillButton: UIView {
     }
 
     private func setUpSelf() {
-        backgroundColor = UIColor(named: "Gray00")
+        backgroundColor = UIColor.Eatery.gray00
 
         addSubview(imageView)
         setUpImageView()
@@ -35,13 +35,13 @@ class SettingsLogoutPillButton: UIView {
 
     private func setUpImageView() {
         imageView.image = UIImage(named: "Exit")?.withRenderingMode(.alwaysTemplate)
-        imageView.tintColor = UIColor(named: "Black")
+        imageView.tintColor = UIColor.Eatery.black
     }
 
     private func setUpTitleLabel() {
         titleLabel.text = "Log out"
         titleLabel.font = .preferredFont(for: .caption1, weight: .semibold)
-        titleLabel.tintColor = UIColor(named: "Black")
+        titleLabel.tintColor = UIColor.Eatery.black
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/SettingsMain/SettingsMainMenuCell.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsMain/SettingsMainMenuCell.swift
@@ -42,22 +42,22 @@ class SettingsMainMenuCell: UIView {
     }
 
     private func setUpImageView() {
-        imageView.tintColor = UIColor(named: "Gray05")
+        imageView.tintColor = UIColor.Eatery.gray05
         imageView.contentMode = .scaleAspectFit
     }
 
     private func setUpTitleLabel() {
         titleLabel.font = .preferredFont(for: .body, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
     }
 
     private func setUpSubtitleLabel() {
         subtitleLabel.font = .preferredFont(for: .caption1, weight: .semibold)
-        subtitleLabel.textColor = UIColor(named: "Gray05")
+        subtitleLabel.textColor = UIColor.Eatery.gray05
     }
 
     private func setUpChevronImageView() {
-        chevronImageView.tintColor = UIColor(named: "EateryBlue")
+        chevronImageView.tintColor = UIColor.Eatery.blue
         chevronImageView.image = UIImage(named: "ChevronRight")?.withRenderingMode(.alwaysTemplate)
     }
 

--- a/Eatery Blue/Eatery Blue/UI/SettingsMain/SettingsMainMenuLoginStatusView.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsMain/SettingsMainMenuLoginStatusView.swift
@@ -31,7 +31,7 @@ class SettingsMainMenuLoginStatusView: UIView {
     }
 
     private func setUpLabel() {
-        label.textColor = UIColor(named: "Gray05")
+        label.textColor = UIColor.Eatery.gray05
         label.font = .preferredFont(for: .body, weight: .semibold)
     }
 

--- a/Eatery Blue/Eatery Blue/UI/SettingsMain/SettingsMainMenuViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsMain/SettingsMainMenuViewController.swift
@@ -36,11 +36,11 @@ class SettingsMainMenuViewController: UIViewController {
     private func setUpNavigationItem() {
         let appearance = UINavigationBarAppearance()
         appearance.titleTextAttributes = [
-            .foregroundColor: UIColor(named: "Black") as Any,
+            .foregroundColor: UIColor.Eatery.black as Any,
             .font: UIFont.eateryNavigationBarTitleFont
         ]
         appearance.largeTitleTextAttributes = [
-            .foregroundColor: UIColor(named: "EateryBlue") as Any,
+            .foregroundColor: UIColor.Eatery.blue as Any,
             .font: UIFont.eateryNavigationBarLargeTitleFont
         ]
 
@@ -60,7 +60,7 @@ class SettingsMainMenuViewController: UIViewController {
             target: self,
             action: #selector(didTapBackButton)
         )
-        backButton.tintColor = UIColor(named: "Black")
+        backButton.tintColor = UIColor.Eatery.black
         navigationItem.leftBarButtonItem = backButton
     }
 

--- a/Eatery Blue/Eatery Blue/UI/SettingsPrivacy/SettingsPrivacyViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsPrivacy/SettingsPrivacyViewController.swift
@@ -37,11 +37,11 @@ class SettingsPrivacyViewController: UIViewController {
     private func setUpNavigationItem() {
         let appearance = UINavigationBarAppearance()
         appearance.titleTextAttributes = [
-            .foregroundColor: UIColor(named: "Black") as Any,
+            .foregroundColor: UIColor.Eatery.black as Any,
             .font: UIFont.eateryNavigationBarTitleFont
         ]
         appearance.largeTitleTextAttributes = [
-            .foregroundColor: UIColor(named: "EateryBlue") as Any,
+            .foregroundColor: UIColor.Eatery.blue as Any,
             .font: UIFont.eateryNavigationBarLargeTitleFont
         ]
 
@@ -61,7 +61,7 @@ class SettingsPrivacyViewController: UIViewController {
             target: self,
             action: #selector(didTapBackButton)
         )
-        backButton.tintColor = UIColor(named: "Black")
+        backButton.tintColor = UIColor.Eatery.black
         navigationItem.leftBarButtonItem = backButton
     }
 

--- a/Eatery Blue/Eatery Blue/UI/SettingsSupport/SettingsSupportViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/SettingsSupport/SettingsSupportViewController.swift
@@ -35,11 +35,11 @@ class SettingsSupportViewController: UIViewController {
     private func setUpNavigationItem() {
         let appearance = UINavigationBarAppearance()
         appearance.titleTextAttributes = [
-            .foregroundColor: UIColor(named: "Black") as Any,
+            .foregroundColor: UIColor.Eatery.black as Any,
             .font: UIFont.eateryNavigationBarTitleFont
         ]
         appearance.largeTitleTextAttributes = [
-            .foregroundColor: UIColor(named: "EateryBlue") as Any,
+            .foregroundColor: UIColor.Eatery.blue as Any,
             .font: UIFont.eateryNavigationBarLargeTitleFont
         ]
 
@@ -59,7 +59,7 @@ class SettingsSupportViewController: UIViewController {
             target: self,
             action: #selector(didTapBackButton)
         )
-        backButton.tintColor = UIColor(named: "Black")
+        backButton.tintColor = UIColor.Eatery.black
         navigationItem.leftBarButtonItem = backButton
     }
 

--- a/Eatery Blue/Eatery Blue/UI/Sheet/SheetViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/Sheet/SheetViewController.swift
@@ -65,7 +65,7 @@ class SheetViewController: UIViewController {
         let titleLabel = UILabel()
         header.addArrangedSubview(titleLabel)
         titleLabel.font = .preferredFont(for: .title2, weight: .semibold)
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
 
         let attributedText = NSMutableAttributedString()
         if let image = image {
@@ -110,12 +110,12 @@ class SheetViewController: UIViewController {
 
         switch style {
         case .regular:
-            titleLabel.textColor = UIColor(named: "Black")
-            container.cornerRadiusView.backgroundColor = UIColor(named: "Gray00")
+            titleLabel.textColor = UIColor.Eatery.black
+            container.cornerRadiusView.backgroundColor = UIColor.Eatery.gray00
 
         case .prominent:
             titleLabel.textColor = .white
-            container.cornerRadiusView.backgroundColor = UIColor(named: "EateryBlue")
+            container.cornerRadiusView.backgroundColor = UIColor.Eatery.blue
         }
     }
 
@@ -123,7 +123,7 @@ class SheetViewController: UIViewController {
         let titleLabel = UILabel()
         titleLabel.font = .preferredFont(for: .body, weight: .semibold)
         titleLabel.text = title
-        titleLabel.textColor = UIColor(named: "Black")
+        titleLabel.textColor = UIColor.Eatery.black
         titleLabel.textAlignment = .center
 
         let container = ButtonView(content: titleLabel)
@@ -142,13 +142,13 @@ class SheetViewController: UIViewController {
 
         let titleLabel = UILabel()
         titleLabel.text = title
-        titleLabel.textColor = UIColor(named: "Gray05")
+        titleLabel.textColor = UIColor.Eatery.gray05
         titleLabel.font = .preferredFont(for: .subheadline, weight: .medium)
         stack.addArrangedSubview(titleLabel)
 
         let descriptionLabel = UILabel()
         descriptionLabel.text = description
-        descriptionLabel.textColor = UIColor(named: "Black")
+        descriptionLabel.textColor = UIColor.Eatery.black
         descriptionLabel.font = .preferredFont(for: .body, weight: .semibold)
         descriptionLabel.numberOfLines = 0
         stack.addArrangedSubview(descriptionLabel)

--- a/Eatery Blue/Eatery Blue/UI/Util/HDivider.swift
+++ b/Eatery Blue/Eatery Blue/UI/Util/HDivider.swift
@@ -12,7 +12,7 @@ class HDivider: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        backgroundColor = UIColor(named: "Gray00")
+        backgroundColor = UIColor.Eatery.gray00
         snp.makeConstraints { make in
             make.height.equalTo(1)
         }

--- a/Eatery Blue/Eatery Blue/UI/Util/VDivider.swift
+++ b/Eatery Blue/Eatery Blue/UI/Util/VDivider.swift
@@ -12,7 +12,7 @@ class VDivider: UIView {
     init(width: CGFloat = 1) {
         super.init(frame: .zero)
 
-        self.backgroundColor = UIColor(named: "Gray00")
+        self.backgroundColor = UIColor.Eatery.gray00
         snp.makeConstraints { make in
             make.width.equalTo(width)
         }

--- a/Eatery Blue/Eatery Blue/UI/WaitTimesSheet/WaitTimeCell.swift
+++ b/Eatery Blue/Eatery Blue/UI/WaitTimesSheet/WaitTimeCell.swift
@@ -41,14 +41,14 @@ class WaitTimeCell: UIView {
 
     private func setUpStartTimeLabel() {
         startTimeLabel.font = .preferredFont(for: .caption2, weight: .semibold)
-        startTimeLabel.textColor = UIColor(named: "Gray02")
+        startTimeLabel.textColor = UIColor.Eatery.gray02
         startTimeLabel.backgroundColor = .white
     }
 
     private func setUpBar() {
         bar.layer.cornerRadius = 8
         bar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        bar.backgroundColor = UIColor(named: "EateryBlueMedium")
+        bar.backgroundColor = UIColor.Eatery.blueMedium
     }
 
     private func setUpConstraints() {

--- a/Eatery Blue/Eatery Blue/UI/WaitTimesSheet/WaitTimesSheetViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/WaitTimesSheet/WaitTimesSheetViewController.swift
@@ -80,20 +80,20 @@ class WaitTimesSheetViewController: SheetViewController {
     }
 
     private func setUpWaitTimeLabel() {
-        waitTimeLabel.textColor = UIColor(named: "EateryBlue")
+        waitTimeLabel.textColor = UIColor.Eatery.blue
         waitTimeLabel.font = .preferredFont(for: .headline, weight: .semibold)
         stackView.addArrangedSubview(waitTimeLabel)
     }
 
     private func setUpDayLabel() {
         dayLabel.text = dayFormatter.string(from: day.date())
-        dayLabel.textColor = UIColor(named: "Gray05")
+        dayLabel.textColor = UIColor.Eatery.gray05
         dayLabel.font = .preferredFont(for: .subheadline, weight: .medium)
         stackView.addArrangedSubview(dayLabel)
     }
 
     private func setUpVisibleTimesLabel() {
-        visibleTimesLabel.textColor = UIColor(named: "Black")
+        visibleTimesLabel.textColor = UIColor.Eatery.black
         visibleTimesLabel.font = .preferredFont(for: .body, weight: .semibold)
         visibleTimesLabel.numberOfLines = 0
         stackView.addArrangedSubview(visibleTimesLabel)

--- a/Eatery Blue/Eatery Blue/UI/WaitTimesSheet/WaitTimesView.swift
+++ b/Eatery Blue/Eatery Blue/UI/WaitTimesSheet/WaitTimesView.swift
@@ -54,7 +54,7 @@ class WaitTimesView: UIView {
         clipsToBounds = true
         layer.cornerRadius = 8
         layer.borderWidth = 1
-        layer.borderColor = UIColor(named: "Gray01")?.cgColor
+        layer.borderColor = UIColor.Eatery.gray01.cgColor
 
         addSubview(scrollView)
         setUpScrollView()
@@ -76,7 +76,7 @@ class WaitTimesView: UIView {
     }
 
     private func setUpConnectingLine() {
-        connectingLine.backgroundColor = UIColor(named: "EateryBlue")
+        connectingLine.backgroundColor = UIColor.Eatery.blue
         connectingLine.alpha = 0
     }
 
@@ -84,7 +84,7 @@ class WaitTimesView: UIView {
         waitTimeLabel.content.font = .preferredFont(for: .caption2, weight: .semibold)
         waitTimeLabel.content.textColor = .white
         waitTimeLabel.cornerRadius = 4
-        waitTimeLabel.cornerRadiusView.backgroundColor = UIColor(named: "EateryBlue")
+        waitTimeLabel.cornerRadiusView.backgroundColor = UIColor.Eatery.blue
         waitTimeLabel.layoutMargins = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
         waitTimeLabel.alpha = 0
     }
@@ -150,7 +150,7 @@ class WaitTimesView: UIView {
 
     func dehighlightCells() {
         if let previousIndex = highlightedIndex {
-            cells[previousIndex].bar.backgroundColor = UIColor(named: "EateryBlueMedium")
+            cells[previousIndex].bar.backgroundColor = UIColor.Eatery.blueMedium
         }
         highlightedIndex = nil
 
@@ -173,12 +173,12 @@ class WaitTimesView: UIView {
         }
 
         if let previousIndex = highlightedIndex {
-            cells[previousIndex].bar.backgroundColor = UIColor(named: "EateryBlueMedium")
+            cells[previousIndex].bar.backgroundColor = UIColor.Eatery.blueMedium
         }
         highlightedIndex = index
 
 
-        cell.bar.backgroundColor = UIColor(named: "EateryBlue")
+        cell.bar.backgroundColor = UIColor.Eatery.blue
 
         connectingLine.alpha = 1
         waitTimeLabel.alpha = 1


### PR DESCRIPTION
## Overview

I created a UIColor extension to make accessing colors easier throughout the project.

## Changes Made

The first main change is an extra file in extensions (UIColor.swift) which has an enum of static colors. The second main change is in every file that uses `UIColor(named: "exampleColor")` it is rewritten to use this enum `UIColor.Eatery.exampleColor`

## Test Coverage

I checked the homepage files, along with some of the easy-to-access UI features to make sure the colors looked the same before and after the refactoring. 