### PR TITLE
Removed white bar at bottom

### DIFF
--- a/Eatery Blue/Eatery Blue/UI/EateryScreen/EateryPageViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryScreen/EateryPageViewController.swift
@@ -35,6 +35,15 @@ class EateryPageViewController: UIPageViewController {
         setUpPages()
     }
     
+    override func viewDidLayoutSubviews() {
+        for subview in view.subviews {
+            if subview is UIScrollView {
+                subview.frame = self.view.bounds
+            }
+        }
+        super.viewDidLayoutSubviews()
+    }
+    
     private func setUpPages() {
         eateries.forEach { eatery in
             let eateryVC = EateryModelController()
@@ -68,15 +77,4 @@ extension EateryPageViewController: UIPageViewControllerDataSource {
         return index
     }
     
-}
-
-extension EateryPageViewController {
-    override func viewDidLayoutSubviews() {
-        for subview in self.view.subviews {
-            if subview is UIScrollView {
-                subview.frame = self.view.bounds
-            }
-        }
-        super.viewDidLayoutSubviews()
-    }
 }

--- a/Eatery Blue/Eatery Blue/UI/EateryScreen/EateryPageViewController.swift
+++ b/Eatery Blue/Eatery Blue/UI/EateryScreen/EateryPageViewController.swift
@@ -36,9 +36,9 @@ class EateryPageViewController: UIPageViewController {
     }
     
     override func viewDidLayoutSubviews() {
-        for subview in view.subviews {
+        view.subviews.forEach { subview in
             if subview is UIScrollView {
-                subview.frame = self.view.bounds
+                subview.frame = view.bounds
             }
         }
         super.viewDidLayoutSubviews()


### PR DESCRIPTION
## Overview

- Removed the white bar so that the entire contents of individual eatery pages are shown (based on feedback from design)

## Changes Made

- Override viewDidLayoutSubviews func so that the scroll view fills the entire view

## Test Coverage

- Tested on iPhone 14 (all sizes).

## Related PRs or Issues

- Related to PR #9 (and Jennifer's feedback)

## Screenshots

<details>

<img src = "https://user-images.githubusercontent.com/87658310/227781893-7201d996-ccdc-4ef4-b5ba-520bcbbbf6b3.png" width = "300px" height = "auto">
<img src = "https://user-images.githubusercontent.com/87658310/227781905-bdf44189-d80d-49a1-a8bf-c8d6d197f889.png" width = "300px" height = "auto">

</details>
