### PR TITLE
Bug fix: Nearest to you carousel view reloading each time it is viewed

### DIFF
--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -22,6 +22,8 @@ class HomeModelController: HomeViewController {
 
     private var cancellables: Set<AnyCancellable> = []
 
+    private lazy var loadCells: () = updateCellsFromState()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.isUserInteractionEnabled = false
@@ -40,7 +42,7 @@ class HomeModelController: HomeViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        updateCellsFromState()
+        let _ = loadCells
 
         LocationManager.shared.requestAuthorization()
         LocationManager.shared.requestLocation()


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

- Update home screen only when user refreshes to allow carousel view to remain in the same scrolling position
    - only call `updateCellsFromState()` in `viewWillAppear` of home screen the first time it loads
- `didRefresh` remains unchanged so user is still able to refresh the page to receive new 'Nearest to you' eateries


## Related PRs or Issues

<!-- List related PRs against other branches/repositories. -->

Addresses Issue https://github.com/cuappdev/eatery-blue-ios/issues/33
