### PR TITLE
Deleted onboarding pages and changes onboarding button title

### DIFF
--- a/Eatery Blue.xcodeproj/project.pbxproj
+++ b/Eatery Blue.xcodeproj/project.pbxproj
@@ -154,8 +154,8 @@
 		99BA26F629F8A8CE007BE992 /* EateryMediumLoadingCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BA26F529F8A8CE007BE992 /* EateryMediumLoadingCardView.swift */; };
 		BC463AB62A862067002FA81A /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC463AB52A862067002FA81A /* UIImageView.swift */; };
 		BC4A94ED29F9BEB3007198BC /* EateryCardShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4A94EC29F9BEB3007198BC /* EateryCardShimmerView.swift */; };
-		BC939CE229F89A9100810787 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BC939CE129F89A9000810787 /* GoogleService-Info.plist */; };
 		BFD955952900A8150049D77C /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD955942900A8150049D77C /* UIColor.swift */; };
+		FD5203952ABFF74A00E9FBDE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FD5203942ABFF74A00E9FBDE /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -307,8 +307,8 @@
 		99BA26F529F8A8CE007BE992 /* EateryMediumLoadingCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EateryMediumLoadingCardView.swift; sourceTree = "<group>"; };
 		BC463AB52A862067002FA81A /* UIImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageView.swift; sourceTree = "<group>"; };
 		BC4A94EC29F9BEB3007198BC /* EateryCardShimmerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EateryCardShimmerView.swift; sourceTree = "<group>"; };
-		BC939CE129F89A9000810787 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		BFD955942900A8150049D77C /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
+		FD5203942ABFF74A00E9FBDE /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -472,7 +472,7 @@
 		5D86517D2773CBFB000338D4 /* Eatery Blue */ = {
 			isa = PBXGroup;
 			children = (
-				BC939CE129F89A9000810787 /* GoogleService-Info.plist */,
+				FD5203942ABFF74A00E9FBDE /* GoogleService-Info.plist */,
 				5DCB869B2782396000134066 /* main.swift */,
 				5D86517E2773CBFB000338D4 /* AppDelegate.swift */,
 				5D8651802773CBFB000338D4 /* SceneDelegate.swift */,
@@ -902,8 +902,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				5D86518B2773CBFB000338D4 /* LaunchScreen.storyboard in Resources */,
+				FD5203952ABFF74A00E9FBDE /* GoogleService-Info.plist in Resources */,
 				5D8651882773CBFB000338D4 /* Assets.xcassets in Resources */,
-				BC939CE229F89A9100810787 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Eatery Blue/UI/Onboarding/OnboardingFeaturesViewController.swift
+++ b/Eatery Blue/UI/Onboarding/OnboardingFeaturesViewController.swift
@@ -28,17 +28,14 @@ class OnboardingFeaturesViewController: UIViewController {
 
         setUpView()
         setUpConstraints()
-
+        
+        // Mark : - Deleted the Wait Times page in onboarding
+        
         setUpPages([
             OnboardingPage(
                 title: "Upcoming Menus",
                 subtitle: "See menus by date and plan ahead",
                 image: UIImage(named: "OnboardingUpcomingMenus")
-            ),
-            OnboardingPage(
-                title: "Wait Times",
-                subtitle: "Check for crowds in real time to avoid lines",
-                image: UIImage(named: "OnboardingWaitTimes")
             ),
             OnboardingPage(
                 title: "Favorites",
@@ -158,10 +155,18 @@ class OnboardingFeaturesViewController: UIViewController {
         let clampedIndex = max(0, min(pages.count - 1, currentIndex))
         let nextIndex = clampedIndex + 1
 
+        // Mark : Changed nextButton text to "Lets go!" to transition onboarding to HomeModel view
+        
+        if nextIndex == pages.count - 1 {
+            nextButton.content.text = "Lets go!"
+        }
+
         if nextIndex == pages.count {
             // We've reached the last page
-
-            let viewController = OnboardingLoginModelController()
+            
+            // Mark : Deleted login page directly after onboarding
+            
+            let viewController = HomeModelController()
             navigationController?.pushViewController(viewController, animated: true)
 
         } else {


### PR DESCRIPTION
## Overview

- Deleted Wait Times and and Login pages
- Changed button title to lets go

## Changes Made

- On last on boarding page the button title changes to "Lets go!"

## Test Coverage

Used Manual testing. All changes are visible when first entering the app in the on boarding pages.

## Next Steps

Fully implement a working Wait Times and Login page and add them in again. Change the button title back to next when completed.

## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>On boarding Pages</summary>


  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
 Upcoming menus
![Simulator Screen Shot - iPhone 14 Pro - 2023-09-24 at 23 58 45](https://github.com/cuappdev/eatery-blue-ios/assets/46629787/9783e8cf-37e1-4055-8f46-e7aefac108c4)

Straight to Favorites (Button says Lets go) skipping Wait times page
![Simulator Screen Shot - iPhone 14 Pro - 2023-09-24 at 23 58 52](https://github.com/cuappdev/eatery-blue-ios/assets/46629787/73fb7e24-92c8-479b-a6e3-6b625b2f4704)

Straight to Home page skipping login page
![Simulator Screen Shot - iPhone 14 Pro - 2023-09-24 at 23 58 57](https://github.com/cuappdev/eatery-blue-ios/assets/46629787/6bc2c820-1960-4dbc-a67d-a1544650d8b1)


</details>
