### PR TITLE
Change eatery order so open eateries on top

### DIFF
--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -77,11 +77,11 @@ class HomeModelController: HomeViewController {
             let eateries = isTesting ? DummyData.eateries : try await Networking.default.eateries.fetch(maxStaleness: 0)
             allEateries = eateries.filter { eatery in
                 return !eatery.name.isEmpty
-            }.sorted(by: { lhs, rhs in
-                if (lhs.isOpen == rhs.isOpen){
-                    lhs.name < rhs.name
+            }.sorted(by: {
+                if $0.isOpen == $1.isOpen{
+                    $0.name < $1.name
                 } else {
-                    lhs.isOpen
+                    $0.isOpen
                 }
             })
 

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -78,7 +78,11 @@ class HomeModelController: HomeViewController {
             allEateries = eateries.filter { eatery in
                 return !eatery.name.isEmpty
             }.sorted(by: { lhs, rhs in
-                lhs.name < rhs.name
+                if (lhs.isOpen == rhs.isOpen){
+                    lhs.name < rhs.name
+                } else {
+                    lhs.isOpen
+                }
             })
 
         } catch {

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -78,7 +78,7 @@ class HomeModelController: HomeViewController {
             allEateries = eateries.filter { eatery in
                 return !eatery.name.isEmpty
             }.sorted(by: {
-                if $0.isOpen == $1.isOpen{
+                if $0.isOpen == $1.isOpen {
                     $0.name < $1.name
                 } else {
                     $0.isOpen


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Change dining hall order on home page

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

- Dining Halls that are open are moved to the top of page
- Dining Halls that are open and closed are separately sorted in alphabetical order

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repo steps and/or how to turn the feature on if applicable. -->

Used Manual testing. Visible on Home page.

## Screenshots (delete if not applicable)

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>Screen Shot Name</summary>
Open dining halls on top

  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->
  
![Simulator Screenshot - iPhone 15 Pro - 2023-09-27 at 22 53 46](https://github.com/cuappdev/eatery-blue-ios/assets/46629787/b9eb37a6-48eb-4b53-a864-e8f4f3739dfe)


</details>
