### PR TITLE
[DO NOT MERGE] Fix loading times

### DIFF
--- a/Eatery Blue.xcodeproj/project.pbxproj
+++ b/Eatery Blue.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2EE42C5E2AC61EA800253843 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2EE42C5D2AC61EA800253843 /* GoogleService-Info.plist */; };
 		5D0B9D70279F1657004B4AA1 /* SettingsFavoritesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0B9D6F279F1657004B4AA1 /* SettingsFavoritesViewController.swift */; };
 		5D0B9D74279F1C5A004B4AA1 /* SettingsFavoritesModelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0B9D73279F1C5A004B4AA1 /* SettingsFavoritesModelController.swift */; };
 		5D0B9D77279F1D73004B4AA1 /* SettingsPrivacyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0B9D76279F1D73004B4AA1 /* SettingsPrivacyViewController.swift */; };
@@ -154,7 +155,6 @@
 		99BA26F629F8A8CE007BE992 /* EateryMediumLoadingCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99BA26F529F8A8CE007BE992 /* EateryMediumLoadingCardView.swift */; };
 		BC463AB62A862067002FA81A /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC463AB52A862067002FA81A /* UIImageView.swift */; };
 		BC4A94ED29F9BEB3007198BC /* EateryCardShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4A94EC29F9BEB3007198BC /* EateryCardShimmerView.swift */; };
-		BC939CE229F89A9100810787 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BC939CE129F89A9000810787 /* GoogleService-Info.plist */; };
 		BFD955952900A8150049D77C /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD955942900A8150049D77C /* UIColor.swift */; };
 /* End PBXBuildFile section */
 
@@ -173,6 +173,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2EE42C5D2AC61EA800253843 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		5D0B9D6F279F1657004B4AA1 /* SettingsFavoritesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFavoritesViewController.swift; sourceTree = "<group>"; };
 		5D0B9D73279F1C5A004B4AA1 /* SettingsFavoritesModelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsFavoritesModelController.swift; sourceTree = "<group>"; };
 		5D0B9D76279F1D73004B4AA1 /* SettingsPrivacyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPrivacyViewController.swift; sourceTree = "<group>"; };
@@ -307,7 +308,6 @@
 		99BA26F529F8A8CE007BE992 /* EateryMediumLoadingCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EateryMediumLoadingCardView.swift; sourceTree = "<group>"; };
 		BC463AB52A862067002FA81A /* UIImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageView.swift; sourceTree = "<group>"; };
 		BC4A94EC29F9BEB3007198BC /* EateryCardShimmerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EateryCardShimmerView.swift; sourceTree = "<group>"; };
-		BC939CE129F89A9000810787 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		BFD955942900A8150049D77C /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -472,8 +472,8 @@
 		5D86517D2773CBFB000338D4 /* Eatery Blue */ = {
 			isa = PBXGroup;
 			children = (
-				BC939CE129F89A9000810787 /* GoogleService-Info.plist */,
 				5DCB869B2782396000134066 /* main.swift */,
+				2EE42C5D2AC61EA800253843 /* GoogleService-Info.plist */,
 				5D86517E2773CBFB000338D4 /* AppDelegate.swift */,
 				5D8651802773CBFB000338D4 /* SceneDelegate.swift */,
 				5D377CE427A19B0200F8DC37 /* UserDefaultsKeys.swift */,
@@ -902,8 +902,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				5D86518B2773CBFB000338D4 /* LaunchScreen.storyboard in Resources */,
+				2EE42C5E2AC61EA800253843 /* GoogleService-Info.plist in Resources */,
 				5D8651882773CBFB000338D4 /* Assets.xcassets in Resources */,
-				BC939CE229F89A9100810787 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Eatery Blue.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Eatery Blue.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -177,8 +177,8 @@
         "repositoryURL": "https://github.com/scinfu/SwiftSoup",
         "state": {
           "branch": null,
-          "revision": "45a7566f7ec2de0b977f28e825f8df874f210327",
-          "version": "2.3.6"
+          "revision": "0e96a20ffd37a515c5c963952d4335c89bed50a6",
+          "version": "2.6.0"
         }
       },
       {

--- a/Eatery Blue/UI/EateryScreen/EateryPageViewController.swift
+++ b/Eatery Blue/UI/EateryScreen/EateryPageViewController.swift
@@ -58,7 +58,6 @@ class EateryPageViewController: UIPageViewController {
     
     func updateEateries(eateries: [Eatery]) {
         self.eateries = eateries
-        print("updating")
         setUpPages()
     }
     

--- a/Eatery Blue/UI/EateryScreen/EateryPageViewController.swift
+++ b/Eatery Blue/UI/EateryScreen/EateryPageViewController.swift
@@ -9,10 +9,10 @@ import EateryModel
 import UIKit
 
 class EateryPageViewController: UIPageViewController {
-    
-    private var pages = [UIViewController]()
+
     private var eateries = [Eatery]()
     private var index: Int
+    private var pages = [UIViewController]()
     
     init(eateries: [Eatery], index: Int) {
         self.eateries = eateries
@@ -47,17 +47,25 @@ class EateryPageViewController: UIPageViewController {
     }
     
     private func setUpPages() {
-       eateries.forEach { eatery in
+        pages = []
+        eateries.forEach { eatery in
             let eateryVC = EateryModelController()
             eateryVC.setUp(eatery: eatery)
             pages.append(eateryVC)
         }
-        setViewControllers([pages[index]], direction: .forward, animated: true, completion: nil)
+        setViewControllers([pages[index]], direction: .forward, animated: false, completion: nil)
+    }
+    
+    func updateEateries(eateries: [Eatery]) {
+        self.eateries = eateries
+        print("updating")
+        setUpPages()
     }
     
 }
 
 extension EateryPageViewController: UIPageViewControllerDataSource {
+    
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         guard let index = pages.firstIndex(of: viewController) else { return nil }
         let previousIndex = index - 1

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -37,17 +37,13 @@ class HomeModelController: HomeViewController {
                 guard let self = self else { return }
                 
                 group.addTask {
-                    print("1 start")
                     await self.updateSimpleEateriesFromNetworking()
                     await self.updateCellsFromState()
-                    print("1 done")
                 }
                 
                 group.addTask {
-                    print("2 start")
                     await self.updateAllEateriesFromNetworking()
                     await self.updateCellsFromState()
-                    print("2 done")
                 }
             }
         }

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -85,15 +85,16 @@ class HomeModelController: HomeViewController {
     private func updateSimpleEateriesFromNetworking() async {
         do {
             let eateries = isTesting ? DummyData.eateries : try await Networking.simple.eateries.fetch(maxStaleness: 0)
-            allEateries = eateries.filter { eatery in
-                return !eatery.name.isEmpty
-            }.sorted(by: {
-                if $0.isOpen == $1.isOpen {
-                    return $0.name < $1.name
-                }
-                return $0.isOpen
-            })
-
+            if isLoading{
+                allEateries = eateries.filter { eatery in
+                    return !eatery.name.isEmpty
+                }.sorted(by: {
+                    if $0.isOpen == $1.isOpen {
+                        return $0.name < $1.name
+                    }
+                    return $0.isOpen
+                })
+            }
         } catch {
             logger.error("\(error)")
         }

--- a/Eatery Blue/UI/HomeScreen/HomeViewController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeViewController.swift
@@ -33,6 +33,7 @@ class HomeViewController: UIViewController {
     }
 
     let navigationView = HomeNavigationView()
+    private var pageVC: EateryPageViewController?
     private let tableView = UITableView()
     private let tableHeaderView = UIView()
 
@@ -106,9 +107,11 @@ class HomeViewController: UIViewController {
     }
 
     func pushViewController(eateryIndex: Int) {
-        let pageVC = EateryPageViewController(eateries: eateries, index: eateryIndex)
-        navigationController?.hero.isEnabled = false
-        navigationController?.pushViewController(pageVC, animated: true)
+        pageVC = EateryPageViewController(eateries: eateries, index: eateryIndex)
+        if let pageVC = pageVC {
+            navigationController?.hero.isEnabled = false
+            navigationController?.pushViewController(pageVC, animated: true)
+        }
     }
 
     private func updateScrollViewContentInset() {
@@ -285,6 +288,8 @@ extension HomeViewController: UITableViewDataSource {
         self.eateries = allEateries
         self.extraIndex = eateryStartIndex
         tableView.reloadData()
+        
+        pageVC?.updateEateries(eateries: allEateries)
     }
 
 }

--- a/Eatery Blue/main.swift
+++ b/Eatery Blue/main.swift
@@ -73,6 +73,8 @@ struct EateryBlue: ParsableCommand {
 extension Networking {
 
     static var `default` = Networking(fetchUrl: URL(string: "https://eatery-dev.cornellappdev.com/eatery/")!)
+    
+    static var `simple` = Networking(fetchUrl: URL(string: "https://eatery-dev.cornellappdev.com/eatery/simple/")!)
 
 }
 


### PR DESCRIPTION
## Overview
Fixed the long loading times at first launch.

## Changes Made
- Used the “simple” endpoint to fetch eateries for the home page.
    - Because this endpoint returns less data, the response time is significantly quicker.
- Both endpoints are ran asynchronously on a background thread at the same time. When each endpoint is finished, the UI gets updated automatically.
- There are two cases that we need to handle:
    1. The user waits long enough that wen they tap on the Eatery cell, all menus from the longer endpoint are already loaded in.
    2. The user immediately clicks on the Eatery cell when the longer endpoint has not finished. In this case, the `EateryPageViewController` gets automatically updated as soon as the longer endpoint is finished.
- Additionally, these Eateries are sorted with opened at the very top. If both eateries have the same status, then it is by name descending.

## Test Coverage
- Tested many different cases as mentioned above that the user could do.
- Used print statements to confirm that both endpoints are ran at the exact same time and to see if one of the endpoint has finished before the other.

## Next Steps
- Create a spinner and disable scrolling/interaction in the `EateryPageViewController` when the menus haven’t fully loaded in yet.
    - When they are loaded in, stop the spinner and enable scrolling. Make sure that the menus are smoothly animated into the view instead of immediately popping up.
    - Instead of a basic spinner, we can also do something unique to Eatery, perhaps the spinning Eatery icon or something.
- We will also need to remove the endpoints from our codebase because this is a huge security concern.

## Screenshots

### Case 1
https://github.com/cuappdev/eatery-blue-ios/assets/75594943/c3217237-2afd-4fff-9038-4d2177c92a24

### Case 2
https://github.com/cuappdev/eatery-blue-ios/assets/75594943/41e17905-a4f3-449a-ae8a-3b27caebd266