### PR TITLE
Added empty states and fixed hours formatting

### DIFF
--- a/Eatery Blue.xcodeproj/project.pbxproj
+++ b/Eatery Blue.xcodeproj/project.pbxproj
@@ -1267,7 +1267,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 28;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Eatery Blue/Info.plist";
@@ -1286,7 +1286,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cuappdev.eatery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1305,7 +1305,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 28;
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Eatery Blue/Info.plist";
@@ -1324,7 +1324,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.0.1;
+				MARKETING_VERSION = 3.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.cuappdev.eatery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Eatery Blue/Model/EateryFormatter.swift
+++ b/Eatery Blue/Model/EateryFormatter.swift
@@ -102,7 +102,7 @@ class EateryFormatter {
         if events.isEmpty {
             return "Closed"
         } else {
-            return events.map(formatEventTime(_:)).joined(separator: ", ")
+            return events.map(formatEventTime(_:)).joined(separator: "\n")
         }
     }
     

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -250,35 +250,6 @@ class HomeModelController: HomeViewController {
                 }
             /// Empty state only when Under 10 min or Favorites are empty. If favorites is non-empty, empty state still possible depending on selected location.
             } else {
-                if filter.favoriteEnabled {
-                    let favoriteEateries = allEateries.filter {
-                        AppDelegate.shared.coreDataStack.metadata(eateryId: $0.id).isFavorite
-                    }
-                    let favoriteLocations = favoriteEateries.map { $0.campusArea ?? "" }
-                    let hasFavorites = !favoriteEateries.isEmpty
-                    if favoriteEateries.isEmpty {
-                        cells.append(.titleLabel(title: "No eateries found..."))
-                    }
-                    
-                    else if hasFavorites && filter.north && !filter.west && !filter.central && (favoriteLocations.contains("West") || favoriteLocations.contains("Central")) && !favoriteLocations.contains("North") {
-                        cells.append(.titleLabel(title: "No eateries found..."))
-                    }
-                    else if hasFavorites && !filter.north && filter.west && !filter.central && (favoriteLocations.contains("North") || favoriteLocations.contains("Central")) && !favoriteLocations.contains("West") {
-                        cells.append(.titleLabel(title: "No eateries found..."))
-                    }
-                    else if hasFavorites && !filter.north && !filter.west && filter.central && (favoriteLocations.contains("North") || favoriteLocations.contains("West")) && !favoriteLocations.contains("Central") {
-                        cells.append(.titleLabel(title: "No eateries found..."))
-                    }
-                    else if hasFavorites && (filter.north || filter.west) && !filter.central && favoriteLocations.contains("Central") && !favoriteLocations.contains("North") && !favoriteLocations.contains("West") {
-                        cells.append(.titleLabel(title: "No eateries found..."))
-                    }
-                    else if hasFavorites && (filter.west || filter.central) && !filter.north && favoriteLocations.contains("North") && !favoriteLocations.contains("West") && !favoriteLocations.contains("Central") {
-                        cells.append(.titleLabel(title: "No eateries found..."))
-                    }
-                    else if hasFavorites && (filter.north || filter.central) && !filter.west && favoriteLocations.contains("West") && !favoriteLocations.contains("North") && !favoriteLocations.contains("Central") {
-                        cells.append(.titleLabel(title: "No eateries found..."))
-                    }
-                }
 
                 let predicate = filter.predicate(userLocation: LocationManager.shared.userLocation, departureDate: Date())
                 let filteredEateries = allEateries.filter{
@@ -286,7 +257,7 @@ class HomeModelController: HomeViewController {
                 }
                 currentEateries = filteredEateries
                 
-                if filter.under10MinutesEnabled && filteredEateries.isEmpty {
+                if filteredEateries.isEmpty {
                     cells.append(.titleLabel(title: "No eateries found..."))
                 }
             }

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -248,9 +248,7 @@ class HomeModelController: HomeViewController {
                 if !currentEateries.isEmpty {
                     cells.append(.titleLabel(title: "All Eateries"))
                 }
-            /// Empty state only when Under 10 min or Favorites are empty. If favorites is non-empty, empty state still possible depending on selected location.
             } else {
-
                 let predicate = filter.predicate(userLocation: LocationManager.shared.userLocation, departureDate: Date())
                 let filteredEateries = allEateries.filter{
                     predicate.isSatisfied(by: $0, metadata: coreDataStack.metadata(eateryId: $0.id))

--- a/Eatery Blue/UI/MenusScreen/MenusModelController.swift
+++ b/Eatery Blue/UI/MenusScreen/MenusModelController.swift
@@ -161,21 +161,19 @@ class MenusModelController: MenusViewController {
                 }
             }
 
-            /// Empty state only triggered when Central - breakfast and Central - late dinner selected.
             if filter.central || !filter.central && !filter.west && !filter.north {
                 var didAppendCentralLabel: Bool = false
                 currentEateries.forEach { eatery in
                     if eatery.campusArea == "Central" && eatery.paymentMethods.contains(.mealSwipes) && (currentMealType == "Lunch" || currentMealType == "Dinner")  {
-                        print("Testing -> wrong path")
-                        print(eatery.events)
                         !didAppendCentralLabel ? cells.append(.titleLabel(title: "Central")) : nil
                         didAppendCentralLabel = true
                         cells.append(.expandableCard(expandedEatery: ExpandedEatery(eatery: eatery, selectedMealType: currentMealType, selectedDate: selectedDay)))
                     }
                 }
-                if (filter.central && !filter.north && !filter.west) && !(currentMealType == "Lunch" || currentMealType == "Dinner") {
-                    cells.append(.titleLabel(title: "No eateries found..."))
-                }
+            }
+            
+            if filteredEateries.isEmpty {
+                cells.append(.titleLabel(title: "No eateries found..."))
             }
         }
         

--- a/Eatery Blue/UI/MenusScreen/MenusModelController.swift
+++ b/Eatery Blue/UI/MenusScreen/MenusModelController.swift
@@ -161,14 +161,20 @@ class MenusModelController: MenusViewController {
                 }
             }
 
+            /// Menus are only empty for Central - breakfast and Central - late dinner.
             if filter.central || !filter.central && !filter.west && !filter.north {
                 var didAppendCentralLabel: Bool = false
                 currentEateries.forEach { eatery in
-                    if eatery.campusArea == "Central" && eatery.paymentMethods.contains(.mealSwipes) {
+                    if eatery.campusArea == "Central" && eatery.paymentMethods.contains(.mealSwipes) && (currentMealType == "Lunch" || currentMealType == "Dinner")  {
+                        print("Testing -> wrong path")
+                        print(eatery.events)
                         !didAppendCentralLabel ? cells.append(.titleLabel(title: "Central")) : nil
                         didAppendCentralLabel = true
                         cells.append(.expandableCard(expandedEatery: ExpandedEatery(eatery: eatery, selectedMealType: currentMealType, selectedDate: selectedDay)))
                     }
+                }
+                if (filter.central && !filter.north && !filter.west) && !(currentMealType == "Lunch" || currentMealType == "Dinner") {
+                    cells.append(.titleLabel(title: "No eateries found..."))
                 }
             }
         }

--- a/Eatery Blue/UI/MenusScreen/MenusModelController.swift
+++ b/Eatery Blue/UI/MenusScreen/MenusModelController.swift
@@ -164,7 +164,7 @@ class MenusModelController: MenusViewController {
             if filter.central || !filter.central && !filter.west && !filter.north {
                 var didAppendCentralLabel: Bool = false
                 currentEateries.forEach { eatery in
-                    if eatery.campusArea == "Central" && eatery.paymentMethods.contains(.mealSwipes) && (currentMealType == "Lunch" || currentMealType == "Dinner")  {
+                    if eatery.campusArea == "Central" && eatery.paymentMethods.contains(.mealSwipes) {
                         !didAppendCentralLabel ? cells.append(.titleLabel(title: "Central")) : nil
                         didAppendCentralLabel = true
                         cells.append(.expandableCard(expandedEatery: ExpandedEatery(eatery: eatery, selectedMealType: currentMealType, selectedDate: selectedDay)))

--- a/Eatery Blue/UI/MenusScreen/MenusModelController.swift
+++ b/Eatery Blue/UI/MenusScreen/MenusModelController.swift
@@ -161,7 +161,7 @@ class MenusModelController: MenusViewController {
                 }
             }
 
-            /// Menus are only empty for Central - breakfast and Central - late dinner.
+            /// Empty state only triggered when Central - breakfast and Central - late dinner selected.
             if filter.central || !filter.central && !filter.west && !filter.north {
                 var didAppendCentralLabel: Bool = false
                 currentEateries.forEach { eatery in

--- a/Eatery Blue/UI/Sheet/SheetViewController.swift
+++ b/Eatery Blue/UI/Sheet/SheetViewController.swift
@@ -145,9 +145,14 @@ class SheetViewController: UIViewController {
         titleLabel.textColor = UIColor.Eatery.gray05
         titleLabel.font = .preferredFont(for: .subheadline, weight: .medium)
         stack.addArrangedSubview(titleLabel)
-
+        
+        let attributedString = NSMutableAttributedString(string: description ?? "")
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 4
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attributedString.length))
+        
         let descriptionLabel = UILabel()
-        descriptionLabel.text = description
+        descriptionLabel.attributedText = attributedString
         descriptionLabel.textColor = UIColor.Eatery.black
         descriptionLabel.font = .preferredFont(for: .body, weight: .semibold)
         descriptionLabel.numberOfLines = 0

--- a/Post.swift
+++ b/Post.swift
@@ -1,0 +1,8 @@
+//
+//  Post.swift
+//  A3
+//
+//  Created by Antoinette Marie Torres on 10/26/23.
+//
+
+import Foundation

--- a/Post.swift
+++ b/Post.swift
@@ -1,8 +1,0 @@
-//
-//  Post.swift
-//  A3
-//
-//  Created by Antoinette Marie Torres on 10/26/23.
-//
-
-import Foundation


### PR DESCRIPTION
## Overview

- Fixed the formatting of eatery times.
- Added empty states for upcoming menus, favorite eateries, and under10Mins label.

## Changes Made

- Append title label ("No eateries found...") whenever no eatery matched the user's filtering. For the upcoming menus page, the label shows up whenever a user attempts to filter Breakfast - Central and Late Dinner - Central since Oken never serves these two meals.

## Test Coverage

- Manual testing on iPhone 15 Pro Max.

## Screenshots 

![Simulator Screenshot - iPhone 15 - 2023-11-07 at 00 29 35](https://github.com/cuappdev/eatery-blue-ios/assets/87658310/b2005e1e-3837-4e8e-a40f-98ea819c48d3)

![Simulator Screenshot - iPhone 15 - 2023-11-07 at 00 28 42](https://github.com/cuappdev/eatery-blue-ios/assets/87658310/b89fbbc2-8767-4c35-930d-21e2c4cb44f9)

![Simulator Screenshot - iPhone 15 - 2023-11-07 at 00 29 12](https://github.com/cuappdev/eatery-blue-ios/assets/87658310/97cf7336-6790-4965-8b30-14c3f8b010f5)
