### PR TITLE
Add Refresh Control to Menus View

### DIFF
--- a/Eatery Blue/UI/EateryCard/EateryExpandableCardDetailView.swift
+++ b/Eatery Blue/UI/EateryCard/EateryExpandableCardDetailView.swift
@@ -109,6 +109,9 @@ class EateryExpandableCardDetailView: UIView {
                 if menuCategory.category == "Chef's Table - Sides" {
                     sortedCategories.swapAt(1, i)
                 }
+                if menuCategory.category == "Grill" {
+                    sortedCategories.swapAt(2, i)
+                }
             }
 
             sortedCategories.forEach { category in

--- a/Eatery Blue/UI/EateryScreen/EateryModelController.swift
+++ b/Eatery Blue/UI/EateryScreen/EateryModelController.swift
@@ -233,10 +233,9 @@ class EateryModelController: EateryViewController {
             if menuCategory.category == "Chef's Table - Sides" {
                 sortedCategories.swapAt(1, i)
             }
-//            if menuCategory.category == "Grill" {
-//                sortedCategories.swapAt(2, i)
-//                print("works")
-//            }
+            if menuCategory.category == "Grill" {
+                sortedCategories.swapAt(2, i)
+            }
         }
         return sortedCategories
     }

--- a/Eatery Blue/UI/EateryScreen/EateryModelController.swift
+++ b/Eatery Blue/UI/EateryScreen/EateryModelController.swift
@@ -233,6 +233,10 @@ class EateryModelController: EateryViewController {
             if menuCategory.category == "Chef's Table - Sides" {
                 sortedCategories.swapAt(1, i)
             }
+//            if menuCategory.category == "Grill" {
+//                sortedCategories.swapAt(2, i)
+//                print("works")
+//            }
         }
         return sortedCategories
     }

--- a/Eatery Blue/UI/MenusScreen/MenusNavigationView.swift
+++ b/Eatery Blue/UI/MenusScreen/MenusNavigationView.swift
@@ -36,7 +36,7 @@ class MenusNavigationView: NavigationView {
         largeTitleLabel.textColor = .white
         
         addSubview(logoRefreshControl)
-        logoRefreshControl.isHidden = true
+        logoRefreshControl.isHidden = false
         
         addSubview(scrollView)
         setUpScrollView()

--- a/Eatery Blue/UI/MenusScreen/MenusViewController.swift
+++ b/Eatery Blue/UI/MenusScreen/MenusViewController.swift
@@ -67,6 +67,10 @@ class MenusViewController: UIViewController {
         updateScrollViewContentInset()
     }
     
+    func scrollViewDidScroll(_ tableView: UITableView) {
+        handleNavigationView()
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -120,8 +124,12 @@ class MenusViewController: UIViewController {
     }
     
     private func updateScrollViewContentInset() {
-        let top = navigationView.computeExpandedHeight()
-
+        var top = navigationView.computeExpandedHeight()
+        
+        if navigationView.logoRefreshControl.isRefreshing {
+            top += 44
+        }
+        
         tableView.contentInset.top = top
         tableView.contentInset.bottom = view.safeAreaInsets.bottom
     }


### PR DESCRIPTION
## Overview

Implemented refresh control for upcoming menus page.

## Changes Made

### Upcoming Menus Page

- Added a refresh control for the Upcoming Menus page.
    - Pull down to refresh menus for the day the user is currently on.

## Screenshots


https://github.com/cuappdev/eatery-blue-ios/assets/68167806/defc6d13-03fb-41f9-b0dc-3ba9b8988cf3

