### PR TITLE
Fix location refresh and increase tappable area of favorite buttons

### DIFF
--- a/Eatery Blue/UI/Carousel/CarouselView.swift
+++ b/Eatery Blue/UI/Carousel/CarouselView.swift
@@ -45,7 +45,7 @@ class CarouselView: UIView {
     public func updateCarousel(carouselItems: [Eatery]) {
         buttonImageView.tap { [weak self] _ in
             guard let self else { return }
-            pushListViewController(title: titleLabel.text ?? "", description: "", eateries: carouselItems)
+            pushListViewController(title: title, description: "", eateries: carouselItems)
         }
         
         var sects: [IndexPath] = []
@@ -74,7 +74,16 @@ class CarouselView: UIView {
         }
         collectionView.deleteSections(sectionsToRemove)
     }
-    
+
+    public func fullRefresh(carouselItems: [Eatery]) {
+        buttonImageView.tap { [weak self] _ in
+            guard let self else { return }
+            pushListViewController(title: title, description: "", eateries: carouselItems)
+        }
+        self.carouselItems = carouselItems
+        collectionView.reloadData()
+    }
+
     // MARK: - Setup
     
     private func setUpSelf() {

--- a/Eatery Blue/UI/Carousel/CarouselView.swift
+++ b/Eatery Blue/UI/Carousel/CarouselView.swift
@@ -42,7 +42,7 @@ class CarouselView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public func updateCarousel(carouselItems: [Eatery]) {
+    func updateCarousel(carouselItems: [Eatery]) {
         buttonImageView.tap { [weak self] _ in
             guard let self else { return }
             pushListViewController(title: title, description: "", eateries: carouselItems)
@@ -75,7 +75,7 @@ class CarouselView: UIView {
         collectionView.deleteSections(sectionsToRemove)
     }
 
-    public func fullRefresh(carouselItems: [Eatery]) {
+    func fullRefresh(carouselItems: [Eatery]) {
         buttonImageView.tap { [weak self] _ in
             guard let self else { return }
             pushListViewController(title: title, description: "", eateries: carouselItems)

--- a/Eatery Blue/UI/Carousel/CarouselView.swift
+++ b/Eatery Blue/UI/Carousel/CarouselView.swift
@@ -80,6 +80,7 @@ class CarouselView: UIView {
             guard let self else { return }
             pushListViewController(title: title, description: "", eateries: carouselItems)
         }
+        
         self.carouselItems = carouselItems
         collectionView.reloadData()
     }

--- a/Eatery Blue/UI/EateryCard/EateryLargeCardContentView.swift
+++ b/Eatery Blue/UI/EateryCard/EateryLargeCardContentView.swift
@@ -19,7 +19,8 @@ class EateryLargeCardContentView: UIView {
     private let labelStackView = UIStackView()
     private let titleLabel = UILabel()
     private let subtitleLabels = [UILabel(), UILabel()]
-    private var favoriteButton = ButtonView(content: UIImageView())
+    private var favoriteButton = ButtonView(content: UIView())
+    private var favoriteButtonImage = UIImageView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -52,6 +53,7 @@ class EateryLargeCardContentView: UIView {
         setUpLabelStackView()
 
         addSubview(favoriteButton)
+        favoriteButton.addSubview(favoriteButtonImage)
     }
 
     private func setUpImageView() {
@@ -111,9 +113,9 @@ class EateryLargeCardContentView: UIView {
 
         let metadata = AppDelegate.shared.coreDataStack.metadata(eateryId: eatery.id)
         if metadata.isFavorite {
-            favoriteButton.content.image = UIImage(named: "FavoriteSelected")
+            favoriteButtonImage.image = UIImage(named: "FavoriteSelected")
         } else {
-            favoriteButton.content.image = UIImage(named: "FavoriteUnselected")
+            favoriteButtonImage.image = UIImage(named: "FavoriteUnselected")
         }
         
         favoriteButton.buttonPress { [weak self] _ in
@@ -124,9 +126,9 @@ class EateryLargeCardContentView: UIView {
             coreDataStack.save()
             
             if metadata.isFavorite {
-                self.favoriteButton.content.image = UIImage(named: "FavoriteSelected")
+                favoriteButtonImage.image = UIImage(named: "FavoriteSelected")
             } else {
-                self.favoriteButton.content.image = UIImage(named: "FavoriteUnselected")
+                favoriteButtonImage.image = UIImage(named: "FavoriteUnselected")
             }
 
             NotificationCenter.default.post(
@@ -196,11 +198,15 @@ class EateryLargeCardContentView: UIView {
         }
 
         favoriteButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(12)
-            make.top.equalTo(imageView.snp.bottom).offset(12)
-            make.leading.equalTo(labelStackView.snp.trailing).offset(16)
-            make.width.equalTo(20)
-            make.height.equalTo(20)
+            make.trailing.equalToSuperview()
+            make.top.equalTo(imageView.snp.bottom)
+            make.leading.equalTo(labelStackView.snp.trailing).offset(4)
+            make.size.equalTo(44)
+        }
+
+        favoriteButtonImage.snp.makeConstraints { make in
+            make.size.equalTo(20)
+            make.center.equalToSuperview()
         }
     }
 

--- a/Eatery Blue/UI/EateryCard/EateryLargeCardContentView.swift
+++ b/Eatery Blue/UI/EateryCard/EateryLargeCardContentView.swift
@@ -19,8 +19,8 @@ class EateryLargeCardContentView: UIView {
     private let labelStackView = UIStackView()
     private let titleLabel = UILabel()
     private let subtitleLabels = [UILabel(), UILabel()]
-    private var favoriteButton = ButtonView(content: UIView())
-    private var favoriteButtonImage = UIImageView()
+    private let favoriteButton = ButtonView(content: UIView())
+    private let favoriteButtonImage = UIImageView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Eatery Blue/UI/EateryCard/EateryMediumCardContentView.swift
+++ b/Eatery Blue/UI/EateryCard/EateryMediumCardContentView.swift
@@ -18,7 +18,7 @@ class EateryMediumCardContentView: UIView {
     private let titleLabel = UILabel()
     private let subtitleLabel = UILabel()
     private let favoriteButton = ButtonView(content: UIView())
-    private var favoriteButtonImage = UIImageView()
+    private let favoriteButtonImage = UIImageView()
 
     private let alertView = EateryCardAlertView()
 

--- a/Eatery Blue/UI/EateryCard/EateryMediumCardContentView.swift
+++ b/Eatery Blue/UI/EateryCard/EateryMediumCardContentView.swift
@@ -160,7 +160,7 @@ class EateryMediumCardContentView: UIView {
         favoriteButton.snp.makeConstraints { make in
             make.leading.equalTo(subtitleLabel.snp.trailing).offset(4)
             make.trailing.equalTo(imageView.snp.trailing)
-            make.width.height.equalTo(44)
+            make.size.equalTo(44)
             make.top.equalTo(imageView.snp.bottom)
         }
 

--- a/Eatery Blue/UI/EateryCard/EateryMediumCardContentView.swift
+++ b/Eatery Blue/UI/EateryCard/EateryMediumCardContentView.swift
@@ -17,7 +17,8 @@ class EateryMediumCardContentView: UIView {
 
     private let titleLabel = UILabel()
     private let subtitleLabel = UILabel()
-    private let favoriteButton = ButtonView(content: UIImageView())
+    private let favoriteButton = ButtonView(content: UIView())
+    private var favoriteButtonImage = UIImageView()
 
     private let alertView = EateryCardAlertView()
 
@@ -55,6 +56,7 @@ class EateryMediumCardContentView: UIView {
         setUpSubtitleLabel()
         
         addSubview(favoriteButton)
+        favoriteButton.addSubview(favoriteButtonImage)
     }
 
     private func setUpImageView() {
@@ -98,9 +100,9 @@ class EateryMediumCardContentView: UIView {
 
         let metadata = AppDelegate.shared.coreDataStack.metadata(eateryId: eatery.id)
         if metadata.isFavorite {
-            favoriteButton.content.image = UIImage(named: "FavoriteSelected")
+            favoriteButtonImage.image = UIImage(named: "FavoriteSelected")
         } else {
-            favoriteButton.content.image = UIImage(named: "FavoriteUnselected")
+            favoriteButtonImage.image = UIImage(named: "FavoriteUnselected")
         }
         
         favoriteButton.buttonPress { [weak self] _ in
@@ -112,9 +114,9 @@ class EateryMediumCardContentView: UIView {
             coreDataStack.save()
             
             if metadata.isFavorite {
-                self.favoriteButton.content.image = UIImage(named: "FavoriteSelected")
+                favoriteButtonImage.image = UIImage(named: "FavoriteSelected")
             } else {
-                self.favoriteButton.content.image = UIImage(named: "FavoriteUnselected")
+                favoriteButtonImage.image = UIImage(named: "FavoriteUnselected")
             }
 
             NotificationCenter.default.post(
@@ -157,9 +159,14 @@ class EateryMediumCardContentView: UIView {
         
         favoriteButton.snp.makeConstraints { make in
             make.leading.equalTo(subtitleLabel.snp.trailing).offset(4)
-            make.trailing.equalTo(imageView.snp.trailing).inset(12)
-            make.width.height.equalTo(20)
-            make.top.equalTo(imageView.snp.bottom).offset(12)
+            make.trailing.equalTo(imageView.snp.trailing)
+            make.width.height.equalTo(44)
+            make.top.equalTo(imageView.snp.bottom)
+        }
+
+        favoriteButtonImage.snp.makeConstraints { make in
+            make.size.equalTo(20)
+            make.center.equalToSuperview()
         }
     }
 
@@ -174,9 +181,9 @@ class EateryMediumCardContentView: UIView {
     private func configureFavoriteButton(id: Int64) {
         let metadata = AppDelegate.shared.coreDataStack.metadata(eateryId: id)
         if metadata.isFavorite {
-            favoriteButton.content.image = UIImage(named: "FavoriteSelected")
+            favoriteButtonImage.image = UIImage(named: "FavoriteSelected")
         } else {
-            favoriteButton.content.image = UIImage(named: "FavoriteUnselected")
+            favoriteButtonImage.image = UIImage(named: "FavoriteUnselected")
         }
         
         favoriteButton.buttonPress { [weak self] _ in
@@ -188,9 +195,9 @@ class EateryMediumCardContentView: UIView {
             coreDataStack.save()
             
             if metadata.isFavorite {
-                self.favoriteButton.content.image = UIImage(named: "FavoriteSelected")
+                favoriteButtonImage.image = UIImage(named: "FavoriteSelected")
             } else {
-                self.favoriteButton.content.image = UIImage(named: "FavoriteUnselected")
+                favoriteButtonImage.image = UIImage(named: "FavoriteUnselected")
             }
 
             NotificationCenter.default.post(

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -266,7 +266,7 @@ class HomeModelController: HomeViewController {
         }.map(\.eatery)
         
         if let nearestCarousel {
-            nearestCarousel.updateCarousel(carouselItems: carouselEateries)
+            nearestCarousel.fullRefresh(carouselItems: listEateries)
         } else {
             nearestCarousel = createCarouselView(
                 title: "Nearest to You",


### PR DESCRIPTION
# peter/hotfix-fav-refresh

## Overview

Fixes to favoriting buttons on cards and refreshing nearest eateries carousel

## Changes Made

### Favoriting Buttons

- Increased tappable area of favorite buttons to make them easier to click
- quintupled the tappable area for the button (it was really small before; changed from 20x20 to 44x44)

### Home Location Refresh

- Fixed refresh bug where the nearest eateries carousel would not update when refreshing
    - Was issue in CarouselView.updateCarousel where cells were reloaded but data was not changed (this method is used for updating the cards in the favorites carousel for animation purposes, but is not useful for the nearest eateries carousel)
    - implemented new method fullRefresh which hard updates all the eateries shown in the carousel.

## Screenshots
![Simulator Screen Recording - iPhone 15 Pro - 2024-03-22 at 21 13 35](https://github.com/cuappdev/eatery-blue-ios/assets/86176234/a3022045-a8bd-4672-b227-af294ff6005d)

<img width="317" alt="Screenshot 2024-03-22 at 9 32 12 PM" src="https://github.com/cuappdev/eatery-blue-ios/assets/86176234/7c1504e8-6359-4d2e-ae4c-a26f920ff74f">

![Simulator Screen Recording - iPhone 15 Pro - 2024-03-22 at 21 11 49](https://github.com/cuappdev/eatery-blue-ios/assets/86176234/9ee890c4-088e-4cfc-85c0-b26c661c2a0c)

