### PR TITLE
Add Shimmer for Loading Carousel Items

### DIFF
--- a/Eatery Blue.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Eatery Blue.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -168,8 +168,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "c8ed701b513cf5177118a175d85fbbbcd707ab41",
-          "version": "1.3.0"
+          "revision": "46989693916f56d1186bd59ac15124caef896560",
+          "version": "1.3.1"
         }
       },
       {

--- a/Eatery Blue/UI/EateryCard/EateryCardShimmerView.swift
+++ b/Eatery Blue/UI/EateryCard/EateryCardShimmerView.swift
@@ -28,7 +28,7 @@ class EateryCardShimmerView: UIView {
             switch cardType {
             case .Medium:
                 let height = UIScreen.main.bounds.height/4.0
-                return CGRect(x: 0, y: 0, width: height*(295.0 / 186.0), height: height)
+                return CGRect(x: 0, y: 0, width: height*(270.0 / 186.0), height: height-20)
             case .Large:
                 let height = UIScreen.main.bounds.height/2.0
                 return CGRect(x: 0, y: 0, width: height*(343.0 / 216.0), height: height)

--- a/Eatery Blue/UI/EateryCard/EateryMediumLoadingCardView.swift
+++ b/Eatery Blue/UI/EateryCard/EateryMediumLoadingCardView.swift
@@ -22,7 +22,8 @@ class EateryMediumLoadingCardView: EateryCardShimmerView {
 
     private func setUpConstraints() {
         snp.makeConstraints { make in
-            make.width.equalTo(snp.height).multipliedBy(295.0 / 186.0).priority(.required.advanced(by: -1))
+            make.width.equalTo(snp.height).multipliedBy(270.0 / 186.0).priority(.required.advanced(by: -1))
+            make.height.equalTo(UIScreen.main.bounds.height/4.0 - 20)
         }
     }
 }

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -143,7 +143,7 @@ class HomeModelController: HomeViewController {
         cells.append(.searchBar)
         cells.append(.customView(view: filterController.view))
 
-        if !isLoading {
+        if isLoading {
             cells.append(.loadingLabel(title: "Finding flavorful food..."))
             cells.append(.loadingCard(isLarge: false))
 

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -121,18 +121,6 @@ class HomeModelController: HomeViewController {
             logger.error("\(error)")
         }
     }
-    
-    private func createLoadingCarouselView(
-        title: String
-    ) -> CarouselView {
-        
-        let carouselView = CarouselView(title: "Finding flavorful food...", allItems: [], carouselItems: [], navigationController: navigationController, shouldTruncate: false)
-        carouselView.isUserInteractionEnabled = false
-        carouselView.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
-        carouselView.titleLabel.textColor = UIColor.Eatery.gray02
-
-        return carouselView
-    }
 
     private func createCarouselView(
         title: String,
@@ -155,13 +143,13 @@ class HomeModelController: HomeViewController {
         cells.append(.searchBar)
         cells.append(.customView(view: filterController.view))
 
-        if isLoading {
-            let carouselView = createLoadingCarouselView(title: "Loading nearby eateries...")
-            cells.append(.carouselView(carouselView))
+        if !isLoading {
+            cells.append(.loadingLabel(title: "Finding flavorful food..."))
+            cells.append(.loadingCard(isLarge: false))
 
             cells.append(.loadingLabel(title: "Checking for chow..."))
             for _ in 0...4 {
-                cells.append(.loadingCard)
+                cells.append(.loadingCard(isLarge: true))
             }
         } else {
             if !filter.isEnabled {

--- a/Eatery Blue/UI/HomeScreen/HomeViewController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeViewController.swift
@@ -27,8 +27,8 @@ class HomeViewController: UIViewController {
         case statusLabel(status: Status)
         case loadingLabel(title: String)
         case eateryCard(eatery: Eatery)
-        case loadingCard
-        
+        case loadingCard(isLarge: Bool)
+
         func getEateryId() -> Int64? {
             switch self {
             case .eateryCard(let eatery):
@@ -291,15 +291,34 @@ extension HomeViewController: UITableViewDataSource {
             let cell = ClearTableViewCell(content: container)
             cell.selectionStyle = .none
             return cell
-        case .loadingCard:
-            let contentView = EateryLargeLoadingCardView()
+        case .loadingCard(let isLarge):
+            if isLarge {
+                let contentView = EateryLargeLoadingCardView()
 
-            let cardView = EateryCardVisualEffectView(content: contentView)
-            cardView.layoutMargins = Constants.cardViewLayoutMargins
+                let cardView = EateryCardVisualEffectView(content: contentView)
+                cardView.layoutMargins = Constants.cardViewLayoutMargins
 
-            let cell = ClearTableViewCell(content: cardView)
-            cell.selectionStyle = .none
-            return cell
+                let cell = ClearTableViewCell(content: cardView)
+                cell.selectionStyle = .none
+                return cell
+            } else {
+                let stackView = UIStackView()
+                stackView.distribution = .equalSpacing
+                stackView.spacing = 16
+                stackView.semanticContentAttribute = .forceRightToLeft
+                stackView.isLayoutMarginsRelativeArrangement = true
+                stackView.layoutMargins = Constants.cardViewLayoutMargins
+
+                for _ in 0..<2 {
+                    let contentView = EateryMediumLoadingCardView()
+                    let cardView = EateryCardVisualEffectView(content: contentView)
+                    stackView.addArrangedSubview(cardView)
+                }
+
+                let cell = ClearTableViewCell(content: stackView)
+                cell.selectionStyle = .none
+                return cell
+            }
         case .eateryCard(eatery: let eatery):
             let largeCardContent = EateryLargeCardContentView()
             


### PR DESCRIPTION
## Overview

Implemented shimmer loading cards for carousel items.

## Changes Made

### Home Page

- Added EateryMediumLoadingCardViews while waiting to fetch eatery data (the home page previously only had EateryLargeLoadingCardViews)
- Changed loadingCard to handle medium and large loading cards separately

## Test Coverage

- Forced loadingCards to always be showing to ensure medium and large loading cards were displayed properly

## Screenshots

<img src="https://github.com/cuappdev/eatery-blue-ios/assets/68167806/b2c34ebe-e990-4543-a37c-7a56cadd6a9e" height="auto" width="300">
