### PR TITLE
Remove Nearest Eatery Carousel

### DIFF
--- a/Eatery Blue/UI/Carousel/CarouselMoreEateriesCollectionViewCell.swift
+++ b/Eatery Blue/UI/Carousel/CarouselMoreEateriesCollectionViewCell.swift
@@ -69,5 +69,4 @@ class CarouselMoreEateriesCollectionViewCell: UICollectionViewCell {
             make.top.greaterThanOrEqualToSuperview()
         }
     }
-
 }

--- a/Eatery Blue/UI/Carousel/CarouselView.swift
+++ b/Eatery Blue/UI/Carousel/CarouselView.swift
@@ -33,7 +33,6 @@ class CarouselView: UIView {
         self.navigationController = navigationController
         self.shouldTruncate = shouldTruncate
         super.init(frame: .zero)
-        
         setUpSelf()
         setUpConstraints()
     }

--- a/Eatery Blue/UI/EateryCard/EateryLargeCardContentView.swift
+++ b/Eatery Blue/UI/EateryCard/EateryLargeCardContentView.swift
@@ -7,6 +7,8 @@
 
 import EateryModel
 import UIKit
+import Combine
+
 
 class EateryLargeCardContentView: UIView {
 
@@ -15,12 +17,16 @@ class EateryLargeCardContentView: UIView {
     private let imageView = UIImageView()
     private let imageTintView = UIView()
     private let alertsStackView = UIStackView()
+    
 
     private let labelStackView = UIStackView()
     private let titleLabel = UILabel()
     private let subtitleLabels = [UILabel(), UILabel()]
     private let favoriteButton = ButtonView(content: UIView())
     private let favoriteButtonImage = UIImageView()
+    
+    private var cancellables = Set<AnyCancellable>()
+
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -147,7 +153,19 @@ class EateryLargeCardContentView: UIView {
     
     private func configureSubtitleLabels(eatery: Eatery) {
         subtitleLabels[0].text = eatery.locationDescription
-        subtitleLabels[1].attributedText = EateryFormatter.default.eateryCardFormatter(eatery, date: Date())
+        LocationManager.shared.$userLocation
+            .sink { userLocation in
+                self.subtitleLabels[1].attributedText = EateryFormatter.default.formatEatery(
+                    eatery,
+                    style: .medium,
+                    font: .preferredFont(for: .footnote, weight: .medium),
+                    userLocation: userLocation,
+                    date: Date()
+                ).first
+            }
+            .store(in: &cancellables)
+        
+//        subtitleLabels[1].attributedText = EateryFormatter.default.eateryCardFormatter(eatery, date: Date())
     }
     
     private func configureAlerts(status: EateryStatus) {

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -24,7 +24,6 @@ class HomeModelController: HomeViewController {
     private lazy var loadCells: () = updateCellsFromState()
     
     private var favoriteCarousel: CarouselView?
-    private var nearestCarousel: CarouselView?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -192,10 +191,7 @@ class HomeModelController: HomeViewController {
                 if let carouselView = createFavoriteEateriesCarouselView() {
                     cells.append(.carouselView(carouselView))
                 }
-                if let carouselView = createNearestEateriesCarouselView() {
-                    cells.append(.carouselView(carouselView))
-                }
-
+             
                 currentEateries = allEateries
             } else {
                 let predicate = filter.predicate(userLocation: LocationManager.shared.userLocation, departureDate: Date())
@@ -261,48 +257,6 @@ class HomeModelController: HomeViewController {
         return favoriteCarousel
     }
 
-    private func createNearestEateriesCarouselView() -> CarouselView? {
-        let userLocation = LocationManager.shared.userLocation
-        let departureDate = Date()
-
-        let nearestEateriesAndTotalTime: [(eatery: Eatery, totalTime: TimeInterval)] = allEateries.compactMap {
-            if let totalTime = $0.expectedTotalTime(userLocation: userLocation, departureDate: departureDate) {
-                return (eatery: $0, totalTime: totalTime)
-            } else {
-                return nil
-            }
-        }
-
-        guard !nearestEateriesAndTotalTime.isEmpty else {
-            return nil
-        }
-
-        let carouselEateries = nearestEateriesAndTotalTime.sorted { lhs, rhs in
-            if lhs.eatery.isOpen == rhs.eatery.isOpen {
-                return lhs.totalTime < rhs.totalTime
-            } else {
-                return lhs.eatery.isOpen && !rhs.eatery.isOpen
-            }
-        }.map(\.eatery)
-
-        let listEateries = nearestEateriesAndTotalTime.sorted { lhs, rhs in
-            lhs.totalTime < rhs.totalTime
-        }.map(\.eatery)
-        
-        if let nearestCarousel {
-            nearestCarousel.fullRefresh(carouselItems: listEateries)
-        } else {
-            nearestCarousel = createCarouselView(
-                title: "Nearest to You",
-                description: nil,
-                carouselEateries: carouselEateries,
-                listEateries: listEateries,
-                shouldTruncate: true
-            )
-        }
-
-        return nearestCarousel
-    }
 
     @objc private func didRefresh(_ sender: LogoRefreshControl) {
         LocationManager.shared.requestLocation()

--- a/Eatery Blue/UI/HomeScreen/HomeModelController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeModelController.swift
@@ -170,7 +170,6 @@ class HomeModelController: HomeViewController {
         return carouselView
     }
     
-    
     private func updateCellsFromState() {
         let coreDataStack = AppDelegate.shared.coreDataStack
         var cells: [Cell] = []
@@ -305,7 +304,6 @@ class HomeModelController: HomeViewController {
     @objc func refreshFavorites(_ notification: Notification) {
         updateCellsFromState()
     }
-
 }
 
 extension HomeModelController: EateryFilterViewControllerDelegate {

--- a/Eatery Blue/main.swift
+++ b/Eatery Blue/main.swift
@@ -67,7 +67,6 @@ struct EateryBlue: ParsableCommand {
 
         AppDelegate.main()
     }
-
 }
 
 extension Networking {


### PR DESCRIPTION
## Overview

Remove the Nearest Eatery Carousel Feature from Home Page

## Changes Made

### Change 1

- Removed carousel from Home View

## Test Coverage

- Confirmed that favorites carousel still works 

## Next Steps (optional)

- Moving to implement other UI changes
