### PR TITLE
Configure Firebase Cloud Messaging

### DIFF
--- a/Eatery Blue.xcodeproj/project.pbxproj
+++ b/Eatery Blue.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		BC4A94ED29F9BEB3007198BC /* EateryCardShimmerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4A94EC29F9BEB3007198BC /* EateryCardShimmerView.swift */; };
 		BC5A18A52AC540EC0096FAC1 /* GetLoginWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5A18A42AC540EC0096FAC1 /* GetLoginWebViewController.swift */; };
 		BFD955952900A8150049D77C /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD955942900A8150049D77C /* UIColor+Extension.swift */; };
+		C31EC93B2CF3DEBB00B2E99F /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = C31EC93A2CF3DEBB00B2E99F /* FirebaseMessaging */; };
 		D00DC9592BB370520051D3EC /* CompareMenusTabsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D00DC9582BB370520051D3EC /* CompareMenusTabsViewController.swift */; };
 		D01D80772BC638C900253976 /* CompareMenusInternalOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D01D80762BC638C900253976 /* CompareMenusInternalOnboardingView.swift */; };
 		D03A749B2B92BE9500C14083 /* CompareMenusButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03A749A2B92BE9500C14083 /* CompareMenusButton.swift */; };
@@ -357,6 +358,7 @@
 		BC4A94EC29F9BEB3007198BC /* EateryCardShimmerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EateryCardShimmerView.swift; sourceTree = "<group>"; };
 		BC5A18A42AC540EC0096FAC1 /* GetLoginWebViewController.swift */ = {isa = PBXFileReference; indentWidth = 5; lastKnownFileType = sourcecode.swift; path = GetLoginWebViewController.swift; sourceTree = "<group>"; };
 		BFD955942900A8150049D77C /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		C31EC9392CF3DC0800B2E99F /* Eatery Blue.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Eatery Blue.entitlements"; sourceTree = "<group>"; };
 		D00DC9582BB370520051D3EC /* CompareMenusTabsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareMenusTabsViewController.swift; sourceTree = "<group>"; };
 		D01D80762BC638C900253976 /* CompareMenusInternalOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareMenusInternalOnboardingView.swift; sourceTree = "<group>"; };
 		D03A749A2B92BE9500C14083 /* CompareMenusButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompareMenusButton.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C31EC93B2CF3DEBB00B2E99F /* FirebaseMessaging in Frameworks */,
 				D0DC533E2BBBA48F0034D968 /* Hero in Frameworks */,
 				5DBB59E2278FA3AB0028FE59 /* EateryModel in Frameworks */,
 				5D6C3D6727877980000C518D /* Alamofire in Frameworks */,
@@ -561,6 +564,7 @@
 		5D86517D2773CBFB000338D4 /* Eatery Blue */ = {
 			isa = PBXGroup;
 			children = (
+				C31EC9392CF3DC0800B2E99F /* Eatery Blue.entitlements */,
 				5DCB869B2782396000134066 /* main.swift */,
 				5D86517E2773CBFB000338D4 /* AppDelegate.swift */,
 				5D8651802773CBFB000338D4 /* SceneDelegate.swift */,
@@ -1006,6 +1010,7 @@
 				2ED2FC122BA2D7AA00621028 /* Hero */,
 				2ED2FC152BA2DBEC00621028 /* FirebaseAnalytics */,
 				2ED2FC172BA2DBEC00621028 /* FirebaseCrashlytics */,
+				C31EC93A2CF3DEBB00B2E99F /* FirebaseMessaging */,
 			);
 			productName = "Eatery Blue";
 			productReference = 5D86517B2773CBFB000338D4 /* Eatery Blue.app */;
@@ -1407,6 +1412,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_ENTITLEMENTS = "Eatery Blue/Eatery Blue.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 46;
@@ -1431,7 +1437,7 @@
 				);
 				MARKETING_VERSION = 3.1.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = org.cuappdev.eatery;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.eatery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1450,6 +1456,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_ENTITLEMENTS = "Eatery Blue/Eatery Blue.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 46;
@@ -1473,7 +1480,7 @@
 				);
 				MARKETING_VERSION = 3.1.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = org.cuappdev.eatery;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.eatery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1668,6 +1675,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 5DF5F7D727740D26001ADCDC /* XCRemoteSwiftPackageReference "Kingfisher" */;
 			productName = Kingfisher;
+		};
+		C31EC93A2CF3DEBB00B2E99F /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2ED2FC142BA2DBEC00621028 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/Eatery Blue.xcodeproj/project.pbxproj
+++ b/Eatery Blue.xcodeproj/project.pbxproj
@@ -1437,7 +1437,7 @@
 				);
 				MARKETING_VERSION = 3.1.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.eatery;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cuappdev.eatery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1480,7 +1480,7 @@
 				);
 				MARKETING_VERSION = 3.1.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.eatery;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cuappdev.eatery;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Eatery Blue/AppDelegate.swift
+++ b/Eatery Blue/AppDelegate.swift
@@ -12,16 +12,29 @@ import Kingfisher
 import SnapKit
 import Tactile
 import UIKit
+import FirebaseMessaging
 
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
     static let shared = UIApplication.shared.delegate as! AppDelegate
 
     private(set) lazy var coreDataStack = CoreDataStack()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+
         FirebaseApp.configure()
+
+        // Request notification permissions
+        UNUserNotificationCenter.current().delegate = self
+        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+        UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { granted, error in
+            print("Notification permissions granted: \(granted)")
+            if let error = error {
+                print("Notification permission error: \(error.localizedDescription)")
+            }
+        }
+
+        application.registerForRemoteNotifications()
 
         // Setup AppDevAnnouncements
         AnnouncementNetworking.setupConfig(
@@ -32,6 +45,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         )
 
         return true
+    }
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        // Set APNs token for Firebase Messaging
+        print("APNs device token received: \(deviceToken.map { String(format: "%02.2hhx", $0) }.joined())")
+        Messaging.messaging().apnsToken = deviceToken
+
+        // Fetch FCM token once APNs token is set
+        Messaging.messaging().token { token, error in
+            if let error = error {
+                print("Error fetching FCM token: \(error.localizedDescription)")
+            } else if let token = token {
+                print("FCM registration token: \(token)")
+            }
+        }
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print("Failed to register for remote notifications: \(error.localizedDescription)")
     }
 
     // MARK: UISceneSession Lifecycle
@@ -52,4 +84,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         .portrait
     }
 
+    // MARK: - UNUserNotificationCenterDelegate
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        print("Foreground notification received: \(notification.request.content.userInfo)")
+        completionHandler([.alert, .badge, .sound])
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+        print("Notification tapped: \(response.notification.request.content.userInfo)")
+        completionHandler()
+    }
 }

--- a/Eatery Blue/Eatery Blue.entitlements
+++ b/Eatery Blue/Eatery Blue.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/Eatery Blue/Info.plist
+++ b/Eatery Blue/Info.plist
@@ -2,6 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ANNOUNCEMENTS_COMMON_PATH</key>
+	<string>$(ANNOUNCEMENTS_COMMON_PATH)</string>
+	<key>ANNOUNCEMENTS_HOST</key>
+	<string>$(ANNOUNCEMENTS_HOST)</string>
+	<key>ANNOUNCEMENTS_PATH</key>
+	<string>$(ANNOUNCEMENTS_PATH)</string>
+	<key>ANNOUNCEMENTS_SCHEME</key>
+	<string>$(ANNOUNCEMENTS_SCHEME)</string>
+	<key>EATERY_DEV_URL</key>
+	<string>$(EATERY_DEV_URL)</string>
+	<key>EATERY_PROD_URL</key>
+	<string>$(EATERY_PROD_URL)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>UIApplicationSceneManifest</key>
@@ -21,17 +33,5 @@
 			</array>
 		</dict>
 	</dict>
-	<key>ANNOUNCEMENTS_PATH</key>
-	<string>$(ANNOUNCEMENTS_PATH)</string>
-	<key>EATERY_DEV_URL</key>
-	<string>$(EATERY_DEV_URL)</string>
-	<key>EATERY_PROD_URL</key>
-	<string>$(EATERY_PROD_URL)</string>
-	<key>ANNOUNCEMENTS_HOST</key>
-	<string>$(ANNOUNCEMENTS_HOST)</string>
-	<key>ANNOUNCEMENTS_COMMON_PATH</key>
-	<string>$(ANNOUNCEMENTS_COMMON_PATH)</string>
-	<key>ANNOUNCEMENTS_SCHEME</key>
-	<string>$(ANNOUNCEMENTS_SCHEME)</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Overview

Configured Firebase Cloud Messaging on the iOS side for the Eatery Blue app to enable push notifications. This includes setting up the necessary Firebase and Apple configurations, modifying the app to handle notifications, and adding the required files for proper functionality.

## Changes Made

### Firebase Configuration
- Handle APNs registration and link the APNs token to Firebase.
- Retrieve and print the FCM token for testing.
- Implement notification handling.

## Test Coverage

Verified notifications in the following scenarios:
- Foreground: Handled and displayed notifications via willPresent method.
- Background/Closed: Notifications delivered and displayed in the iOS Notification Center.


## Screenshots (optional)
<img src="https://github.com/user-attachments/assets/85c3336f-d281-4c91-8567-dd003ce8d3aa" width="300px" height="auto">

