### PR TITLE
Fix UI overlap and padding issues

### DIFF
--- a/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
+++ b/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
@@ -65,18 +65,6 @@ class MenuHeaderView: UIView {
         buttonView.backgroundColor = UIColor.Eatery.gray00
         buttonView.layer.cornerRadius = 21
         buttonView.layoutMargins = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 16)
-
-        let titleLabel = UILabel()
-        titleLabel.text = "Change Date"
-        titleLabel.font = .preferredFont(for: .subheadline, weight: .semibold)
-        titleLabel.textColor = UIColor.Eatery.primaryText
-
-        buttonView.addSubview(titleLabel)
-        titleLabel.snp.makeConstraints { make in
-            make.trailing.equalTo(buttonView.layoutMarginsGuide)
-            make.centerY.equalTo(buttonView)
-        }
-
         let imageView = UIImageView()
         imageView.image = UIImage(named: "EateryCalendar")
         imageView.contentMode = .center
@@ -85,6 +73,19 @@ class MenuHeaderView: UIView {
         imageView.snp.makeConstraints { make in
             make.width.height.equalTo(40)
             make.leading.equalTo(buttonView.layoutMarginsGuide)
+            make.centerY.equalTo(buttonView)
+        }
+
+        let titleLabel = UILabel()
+        titleLabel.text = "Change Date"
+        titleLabel.font = .preferredFont(for: .subheadline, weight: .semibold)
+        titleLabel.textColor = UIColor.Eatery.primaryText
+
+        buttonView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints { make in
+//            make.trailing.equalTo(buttonView.layoutMarginsGuide)
+            make.leading.equalTo(imageView.snp.trailing)
+            make.trailing.lessThanOrEqualTo(buttonView.layoutMarginsGuide)
             make.centerY.equalTo(buttonView)
         }
 
@@ -102,6 +103,7 @@ class MenuHeaderView: UIView {
     private func setUpConstraints() {
         titleLabel.snp.makeConstraints { make in
             make.top.leading.equalTo(layoutMarginsGuide)
+            make.trailing.lessThanOrEqualTo(buttonView.snp.leading)
         }
 
         subtitleLabel.snp.makeConstraints { make in
@@ -113,7 +115,8 @@ class MenuHeaderView: UIView {
             make.trailing.equalTo(layoutMarginsGuide)
             make.top.equalTo(layoutMarginsGuide).offset(8)
             make.height.equalTo(42)
-            make.width.equalTo(156)
+//            make.width.equalTo(156)
+            make.width.equalTo(160) // arbitrary guess
         }
 
         menuInaccuracyLabel.snp.makeConstraints { make in

--- a/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
+++ b/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
@@ -83,7 +83,6 @@ class MenuHeaderView: UIView {
 
         buttonView.addSubview(titleLabel)
         titleLabel.snp.makeConstraints { make in
-//            make.trailing.equalTo(buttonView.layoutMarginsGuide)
             make.leading.equalTo(imageView.snp.trailing)
             make.trailing.lessThanOrEqualTo(buttonView.layoutMarginsGuide)
             make.centerY.equalTo(buttonView)
@@ -115,8 +114,7 @@ class MenuHeaderView: UIView {
             make.trailing.equalTo(layoutMarginsGuide)
             make.top.equalTo(layoutMarginsGuide).offset(8)
             make.height.equalTo(42)
-//            make.width.equalTo(156)
-            make.width.equalTo(160) // arbitrary guess
+            make.width.equalTo(160)
         }
 
         menuInaccuracyLabel.snp.makeConstraints { make in

--- a/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
+++ b/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
@@ -71,7 +71,7 @@ class MenuHeaderView: UIView {
 
         buttonView.addSubview(imageView)
         imageView.snp.makeConstraints { make in
-            make.width.height.equalTo(36) // or 16?
+            make.width.height.equalTo(36)
             make.leading.equalTo(buttonView.layoutMarginsGuide)
             make.centerY.equalTo(buttonView)
         }

--- a/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
+++ b/Eatery Blue/UI/EateryScreen/MenuHeaderView.swift
@@ -64,14 +64,14 @@ class MenuHeaderView: UIView {
     private func setUpButtonImageView() {
         buttonView.backgroundColor = UIColor.Eatery.gray00
         buttonView.layer.cornerRadius = 21
-        buttonView.layoutMargins = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 16)
+        buttonView.layoutMargins = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 14)
         let imageView = UIImageView()
         imageView.image = UIImage(named: "EateryCalendar")
         imageView.contentMode = .center
 
         buttonView.addSubview(imageView)
         imageView.snp.makeConstraints { make in
-            make.width.height.equalTo(40)
+            make.width.height.equalTo(36) // or 16?
             make.leading.equalTo(buttonView.layoutMarginsGuide)
             make.centerY.equalTo(buttonView)
         }
@@ -114,7 +114,7 @@ class MenuHeaderView: UIView {
             make.trailing.equalTo(layoutMarginsGuide)
             make.top.equalTo(layoutMarginsGuide).offset(8)
             make.height.equalTo(42)
-            make.width.equalTo(160)
+            make.width.equalTo(156)
         }
 
         menuInaccuracyLabel.snp.makeConstraints { make in

--- a/Eatery Blue/UI/HomeScreen/HomeViewController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeViewController.swift
@@ -46,6 +46,7 @@ class HomeViewController: UIViewController {
         static let loadingHeaderHeight: CGFloat = maxHeaderHeight + 52
         static let collectionViewTopPadding: CGFloat = 8
         static let collectionViewSectionPadding: CGFloat = 16
+        static let collectionViewBottomPadding: CGFloat = 25
         static let isTesting = false
     }
 
@@ -121,7 +122,8 @@ class HomeViewController: UIViewController {
         collectionView.backgroundColor = UIColor.Eatery.surface
         collectionView.contentInsetAdjustmentBehavior = .never
         collectionView.delegate = self
-        collectionView.contentInset.bottom = (tabBarController?.tabBar.frame.height ?? 0) + 25 // 108
+        collectionView.contentInset.bottom = (tabBarController?.tabBar.frame.height ?? 0) + Constants
+            .collectionViewBottomPadding
         collectionView.showsVerticalScrollIndicator = false
 
         collectionView.register(

--- a/Eatery Blue/UI/HomeScreen/HomeViewController.swift
+++ b/Eatery Blue/UI/HomeScreen/HomeViewController.swift
@@ -121,7 +121,7 @@ class HomeViewController: UIViewController {
         collectionView.backgroundColor = UIColor.Eatery.surface
         collectionView.contentInsetAdjustmentBehavior = .never
         collectionView.delegate = self
-        collectionView.contentInset.bottom = tabBarController?.tabBar.frame.height ?? 0
+        collectionView.contentInset.bottom = (tabBarController?.tabBar.frame.height ?? 0) + 25 // 108
         collectionView.showsVerticalScrollIndicator = false
 
         collectionView.register(


### PR DESCRIPTION
## Overview

Fixes 3 UI issues relating to padding and constraints in `MenuHeaderView` and `HomeViewController`.

## Changes Made

### Change 1: Increased bottom inset of the collectionView of Eatery cards in HomeViewController

- Added +25 to `collectionView.contentInset.bottom` so that the collectionView ends aligned with the `CompareMenusButton` bottom inset (108 above the bottom of the screen).
- Prevents the favorites button of the last large Eatery card from being covered by the `CompareMenusButton`. 

### Change 2: "Change Date" button internal spacing fixes and padding adjustments in MenuHeaderView

- Anchored the "Change Date" titleLabel to the "EateryCalendar" imageView to prevent them from overlapping (an issue on smaller phone screens).
- Reduced the internal padding of the imageView frame to 36x36 and reduced the buttonView right layout margin to 14 in order to preserve the full "Change Date" label text (on iPhone 17 Pro).
- Made titleLabel text trail off if needed (e.g. "Change D...") for smaller screens using `.lessThanOrEqualTo()`.

### Change 3: Prevent overlap with the day title

- Made day of the week titleLabel trail off if needed for smaller screens using `lessThanOrEqualTo()` in order to prevent overlap with the "Change Date" button.
- Kept fixed button width of 156 to prevent overlap with longer day labels (e.g. "Closed Today").

## Test Coverage

- Manually tested on iPhone 17 Pro and iPhone Air.
- Small and large Eatery card views for home screen padding.
- Various days of the week including "Closed Today" for "Change Date" button spacing.

## Screenshots

Before fixes:

![IMG_7178](https://github.com/user-attachments/assets/236427eb-2b58-4b82-84e0-936eece90d71)

<img src="https://github.com/user-attachments/assets/a23e674b-2891-4f11-a0b8-a1c214044195" width="280px">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined menu date-change button layout with tighter spacing, resized calendar icon, and improved label alignment to prevent truncation.
  * Increased home screen bottom content spacing for smoother scrolling and better visual balance above the tab bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->