### PR TITLE
Make invalidateToken synchronous

### DIFF
--- a/Eatery Blue/Auth/KeychainAccess.swift
+++ b/Eatery Blue/Auth/KeychainAccess.swift
@@ -35,10 +35,8 @@ class KeychainAccess {
             kSecAttrAccount as String: account
         ]
 
-        Task {
-            let status = SecItemDelete(query as CFDictionary)
-            guard status == errSecSuccess || status == errSecItemNotFound else { return }
-        }
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else { return }
     }
 
     /// Returns token under account if it exists, nil otherwise


### PR DESCRIPTION
## Overview

Makes `invalidateToken` synchronous to avoid a potential race condition in `saveToken` that would cause newly added tokens to be removed. This is a potential cause for the GET refresh issue.

## Test Coverage

I can't test :(

## Next Steps (optional)

Test the GET refresh issue.